### PR TITLE
PPC64: Implement new C1 store_barrier_runtime_stub and C2 zStorePNullNode and update c2_store_barrier_stub.

### DIFF
--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.hpp
@@ -101,6 +101,9 @@ public:
 
   void generate_c1_store_barrier_stub(LIR_Assembler* ce,
                                       ZStoreBarrierStubC1* stub) const;
+
+  void generate_c1_store_barrier_runtime_stub(StubAssembler* sasm,
+                                              bool self_healing) const;
 #endif // COMPILER1
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/ppc/gc/z/z_ppc.ad
+++ b/src/hotspot/cpu/ppc/gc/z/z_ppc.ad
@@ -79,7 +79,8 @@ static void z_store_barrier(MacroAssembler& _masm, const MachNode* node, Registe
   if (node->barrier_data() == ZBarrierElided) {
     z_color(_masm, rnew_zpointer, rnew_zaddress);
   } else {
-    ZStoreBarrierStubC2* const stub = ZStoreBarrierStubC2::create(node, Address(ref_base, disp), rnew_zaddress, rnew_zpointer, is_atomic);
+    bool is_native = (node->barrier_data() & ZBarrierNative) != 0;
+    ZStoreBarrierStubC2* const stub = ZStoreBarrierStubC2::create(node, Address(ref_base, disp), rnew_zaddress, rnew_zpointer, is_native, is_atomic);
     ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
     bs_asm->store_barrier_fast(&_masm, ref_base, disp, rnew_zaddress, rnew_zpointer, true /* in_nmethod */, is_atomic, *stub->entry(), *stub->continuation());
   }

--- a/src/hotspot/cpu/ppc/gc/z/z_ppc.ad
+++ b/src/hotspot/cpu/ppc/gc/z/z_ppc.ad
@@ -37,7 +37,13 @@ static void z_color(MacroAssembler& _masm, Register dst, Register src) {
   assert_different_registers(dst, src);
   __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatStoreGoodBits);
   __ li(dst, barrier_Relocation::unpatched); // Load color bits.
-  __ rldimi(dst, src, ZPointerLoadShift, 0); // Insert shifted pointer.
+  if (src == noreg) { // noreg encodes null.
+    if (ZPointerLoadShift >= 16) {
+      __ rldicl(dst, dst, 0, 64 - ZPointerLoadShift); // Clear sign extension from li.
+    }
+  } else {
+    __ rldimi(dst, src, ZPointerLoadShift, 0); // Insert shifted pointer.
+  }
 }
 
 static void z_uncolor(MacroAssembler& _masm, Register ref) {
@@ -172,10 +178,25 @@ instruct zStoreP(memoryAlg4 mem, iRegPsrc src, iRegPdst tmp, flagsRegCR0 cr0)
 %{
   predicate(UseZGC && n->as_Store()->barrier_data() != 0);
   match(Set mem (StoreP mem src));
-  effect(TEMP_DEF tmp, KILL cr0);
+  effect(TEMP tmp, KILL cr0);
+  ins_cost(2 * MEMORY_REF_COST);
   format %{ "std    $mem, $src\t# ptr" %}
   ins_encode %{
     z_store_barrier(_masm, this, $mem$$base$$Register, $mem$$disp, $src$$Register, $tmp$$Register, false /* is_atomic */);
+    __ std($tmp$$Register, $mem$$disp, $mem$$base$$Register);
+  %}
+  ins_pipe(pipe_class_default);
+%}
+
+instruct zStorePNull(memoryAlg4 mem, immP_0 zero, iRegPdst tmp, flagsRegCR0 cr0)
+%{
+  predicate(UseZGC && n->as_Store()->barrier_data() != 0);
+  match(Set mem (StoreP mem zero));
+  effect(TEMP tmp, KILL cr0);
+  ins_cost(MEMORY_REF_COST);
+  format %{ "std    $mem, null\t# ptr" %}
+  ins_encode %{
+    z_store_barrier(_masm, this, $mem$$base$$Register, $mem$$disp, noreg, $tmp$$Register, false /* is_atomic */);
     __ std($tmp$$Register, $mem$$disp, $mem$$base$$Register);
   %}
   ins_pipe(pipe_class_default);

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4584,7 +4584,7 @@ class StubGenerator: public StubCodeGenerator {
     Label null_jobject;
     __ cmpdi(CCR0, R3_RET, 0);
     __ beq(CCR0, null_jobject);
-    DecoratorSet decorators = ACCESS_READ | IN_NATIVE;
+    DecoratorSet decorators = ACCESS_READ | IN_NATIVE | ON_STRONG_OOP_REF;
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
     bs->load_at(_masm, decorators, T_OBJECT, R3_RET /*base*/, (intptr_t)0, R3_RET /*dst*/, tmp1, tmp2, MacroAssembler::PRESERVATION_NONE);
     __ bind(null_jobject);


### PR DESCRIPTION
PPC64 build is broken since https://github.com/openjdk/zgc/commit/7508ed98e162fca7d377e8f25c636a477291de39.
We need an implementation of the new C1 store_barrier_runtime_stub.
In addition, I'm adding the C2 zStorePNullNode like in https://github.com/openjdk/zgc/commit/70b343810c188a79674f9a8b8f2c84a0efab9d1b.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/zgc pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.org/zgc pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/zgc/pull/2.diff">https://git.openjdk.org/zgc/pull/2.diff</a>

</details>
