### PR TITLE
Add verify_oop for resolve_jobject when Resolve local handle

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2484,7 +2484,7 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
 
   // Resolve local handle
   access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, value, Address(value, 0), tmp1, tmp2);
-  //verify_oop(value);
+  verify_oop(value);
   b(done);
 
   bind(tagged);
@@ -2501,7 +2501,6 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
                  value, Address(value, -JNIHandles::weak_tag_value), tmp1, tmp2);
   verify_oop(value);
-  // b(done);
 
   bind(done);
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -522,7 +522,7 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
 
   // Resolve global handle
   access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, value, Address(value, 0), tmp1, tmp2);
-  //verify_oop(value);
+  verify_oop(value);
   b(done);
 
   bind(tagged);
@@ -540,7 +540,6 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF, value,
                  Address(value, -JNIHandles::weak_tag_value), tmp1, tmp2);
   verify_oop(value);
-  // b(done);
 
   bind(done);
 }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3843,7 +3843,7 @@ void MacroAssembler::resolve_jobject(Register value,
 
   // Resolve local handle
   access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, value, Address(value, 0), tmp, thread);
-  //verify_oop(value);
+  verify_oop(value);
   jmp(done);
 
   bind(tagged);
@@ -3860,7 +3860,6 @@ void MacroAssembler::resolve_jobject(Register value,
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
                  value, Address(value, -JNIHandles::weak_tag_value), tmp, thread);
   verify_oop(value);
-  jmp(done);
 
   bind(done);
 }


### PR DESCRIPTION
Hi,

When porting zgc_generational, I found that `resolve_jobject` is lack of `verify_oop` when Resolve local handle.

But PPC `verify` the oop:

```
void ZBarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
                                           Register tmp1, Register tmp2,
                                           MacroAssembler::PreservationLevel preservation_level) {
  Label done, tagged, weak_tagged, verify;
  __ cmpdi(CCR0, value, 0);
  __ beq(CCR0, done);         // Use NULL as-is.

  __ andi_(tmp1, value, JNIHandles::tag_mask);
  __ bne(CCR0, tagged);       // Test for tag.

  __ access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, // no uncoloring
                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
=>  __ b(verify);

  __ bind(tagged);
  __ andi_(tmp1, value, JNIHandles::weak_tag_mask);
  __ clrrdi(value, value, JNIHandles::tag_size); // Untag.
  __ bne(CCR0, weak_tagged);   // Test for jweak tag.

  __ access_load_at(T_OBJECT, IN_NATIVE,
                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
  __ b(verify);

  __ bind(weak_tagged);
  __ access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);

  __ bind(verify);
  __ verify_oop(value, FILE_AND_LINE);
  __ bind(done);
}
```

@xmas92   Please review my patch.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/zgc pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/zgc pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/zgc/pull/4.diff">https://git.openjdk.org/zgc/pull/4.diff</a>

</details>
