### PR TITLE
PPC64 fix jni handles

### DIFF
--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
@@ -584,38 +584,6 @@ void ZBarrierSetAssembler::check_oop(MacroAssembler *masm, Register oop, const c
 }
 
 
-void ZBarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
-                                           Register tmp1, Register tmp2,
-                                           MacroAssembler::PreservationLevel preservation_level) {
-  Label done, tagged, weak_tagged, verify;
-  __ cmpdi(CCR0, value, 0);
-  __ beq(CCR0, done);         // Use NULL as-is.
-
-  __ andi_(tmp1, value, JNIHandles::tag_mask);
-  __ bne(CCR0, tagged);       // Test for tag.
-
-  __ access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, // no uncoloring
-                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
-  __ b(verify);
-
-  __ bind(tagged);
-  __ andi_(tmp1, value, JNIHandles::weak_tag_mask);
-  __ clrrdi(value, value, JNIHandles::tag_size); // Untag.
-  __ bne(CCR0, weak_tagged);   // Test for jweak tag.
-
-  __ access_load_at(T_OBJECT, IN_NATIVE,
-                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
-  __ b(verify);
-
-  __ bind(weak_tagged);
-  __ access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
-                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
-
-  __ bind(verify);
-  __ verify_oop(value, FILE_AND_LINE);
-  __ bind(done);
-}
-
 void ZBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,
                                                          Register obj, Register tmp, Label& slowpath) {
   __ block_comment("try_resolve_jobject_in_native (zgc) {");

--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.hpp
@@ -69,10 +69,6 @@ public:
                                   Register src, Register dst, Register count,
                                   Register preserve1, Register preserve2);
 
-  virtual void resolve_jobject(MacroAssembler* masm, Register value,
-                               Register tmp1, Register tmp2,
-                               MacroAssembler::PreservationLevel preservation_level);
-
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);
 

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4575,7 +4575,13 @@ class StubGenerator: public StubCodeGenerator {
     address calls_return_pc = __ last_calls_return_pc();
     __ reset_last_Java_frame();
     // The handle is dereferenced through a load barrier.
-    __ resolve_jobject(R3_RET, tmp1, tmp2, MacroAssembler::PRESERVATION_NONE);
+    Label null_jobject;
+    __ cmpdi(CCR0, R3_RET, 0);
+    __ beq(CCR0, null_jobject);
+    DecoratorSet decorators = ACCESS_READ | IN_NATIVE | ON_STRONG_OOP_REF;
+    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+    bs->load_at(_masm, decorators, T_OBJECT, R3_RET /*base*/, (intptr_t)0, R3_RET /*dst*/, tmp1, tmp2, MacroAssembler::PRESERVATION_NONE);
+    __ bind(null_jobject);
     __ pop_frame();
     __ ld(tmp1, _abi0(lr), R1_SP);
     __ mtlr(tmp1);


### PR DESCRIPTION
Fix PPC64 code after https://github.com/openjdk/zgc/commit/202bcbfd36898891e120a0ffb0fdb9ba0d96ed11:

- Move ZGC version of `resolve_jobject` to barrierSetAssembler_ppc.cpp which is already tested and replaces the untested and buggy version.
- Revert the changes to `generate_jfr_write_checkpoint()`. The current code looks better, but, unfortunately, it doesn't work with G1 which has restrictions regarding register usage. The lengthy code looks still correct to me (the `JfrJavaEventWriter` doesn't use a weak reference, so we don't need `resolve_jobject` to check for weak reference in this particular case).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/zgc pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/zgc pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/zgc/pull/5.diff">https://git.openjdk.org/zgc/pull/5.diff</a>

</details>
