### PR TITLE
Reuse z_color, z_uncolor and check_color for x86_64 and aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
@@ -158,6 +158,12 @@ public:
 
   void patch_barriers() {}
 
+  void z_color(MacroAssembler* masm, Register dst, Register src, Register tmp) const;
+
+  void z_uncolor(MacroAssembler* masm, Register ref) const;
+
+  void check_color(MacroAssembler* masm, Register ref, Register tmp) const;
+
 #ifdef COMPILER1
   void generate_c1_color(LIR_Assembler* ce, LIR_Opr ref) const;
   void generate_c1_uncolor(LIR_Assembler* ce, LIR_Opr ref) const;

--- a/src/hotspot/cpu/aarch64/gc/z/z_aarch64.ad
+++ b/src/hotspot/cpu/aarch64/gc/z/z_aarch64.ad
@@ -33,23 +33,12 @@ source %{
 
 #include "gc/z/zBarrierSetAssembler.hpp"
 
-static void z_color(MacroAssembler& _masm, const MachNode* node, Register dst, Register src, Register tmp) {
-  __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatStoreGoodBeforeMov);
-  __ movzw(tmp, barrier_Relocation::unpatched);
-  __ orr(dst, tmp, src, Assembler::LSL, ZPointerLoadShift);
-}
-
-static void z_uncolor(MacroAssembler& _masm, const MachNode* node, Register ref) {
-  __ lsr(ref, ref, ZPointerLoadShift);
-}
-
 static void z_keep_alive_load_barrier(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register ref, Register tmp) {
-  __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatMarkBadBeforeMov);
-  __ movzw(tmp, barrier_Relocation::unpatched);
-  __ tst(ref, tmp);
+  ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+  bs_asm->check_color(&_masm, ref, tmp);
   ZLoadBarrierStubC2* const stub = ZLoadBarrierStubC2::create(node, ref_addr, ref);
   __ br(Assembler::NE, *stub->entry());
-  z_uncolor(_masm, node, ref);
+  bs_asm->z_uncolor(&_masm, ref);
   __ bind(*stub->continuation());
 }
 
@@ -64,8 +53,9 @@ static void z_load_barrier(MacroAssembler& _masm, const MachNode* node, Address 
     return;
   }
 
+  ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
   if (node->barrier_data() == ZBarrierElided) {
-    z_uncolor(_masm, node, ref);
+    bs_asm->z_uncolor(&_masm, ref);
     return;
   }
 
@@ -80,18 +70,18 @@ static void z_load_barrier(MacroAssembler& _masm, const MachNode* node, Address 
     __ b(*stub->entry());
     __ bind(good);
   }
-  z_uncolor(_masm, node, ref);
+  bs_asm->z_uncolor(&_masm, ref);
   __ bind(*stub->continuation());
 }
 
 static void z_store_barrier(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register rnew_zaddress, Register rnew_zpointer, Register tmp, bool is_atomic) {
   Assembler::InlineSkippedInstructionsCounter skipped_counter(&_masm);
+  ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
   if (node->barrier_data() == ZBarrierElided) {
-    z_color(_masm, node, rnew_zpointer, rnew_zaddress, rnew_zpointer);
+    bs_asm->z_color(&_masm, rnew_zpointer, rnew_zaddress, rnew_zpointer);
   } else {
     bool is_native = (node->barrier_data() & ZBarrierNative) != 0;
     ZStoreBarrierStubC2Aarch64* const stub = ZStoreBarrierStubC2Aarch64::create(node, ref_addr, rnew_zaddress, rnew_zpointer, is_native, is_atomic);
-    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
     bs_asm->store_barrier_fast(&_masm, ref_addr, rnew_zaddress, rnew_zpointer, tmp, true /* in_nmethod */, is_atomic, *stub->entry(), *stub->continuation());
   }
 }
@@ -186,7 +176,8 @@ instruct zCompareAndSwapP(iRegINoSp res, indirect mem, iRegP oldval, iRegP newva
   ins_encode %{
     guarantee($mem$$index == -1 && $mem$$disp == 0, "impossible encoding");
     Address ref_addr($mem$$Register);
-    z_color(_masm, this, $oldval_tmp$$Register, $oldval$$Register, $oldval_tmp$$Register);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->z_color(&_masm, $oldval_tmp$$Register, $oldval$$Register, $oldval_tmp$$Register);
     z_store_barrier(_masm, this, ref_addr, $newval$$Register, $newval_tmp$$Register, rscratch2, true /* is_atomic */);
     __ cmpxchg($mem$$Register, $oldval_tmp$$Register, $newval_tmp$$Register, Assembler::xword,
                false /* acquire */, true /* release */, false /* weak */, noreg);
@@ -210,7 +201,8 @@ instruct zCompareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP ne
   ins_encode %{
     guarantee($mem$$index == -1 && $mem$$disp == 0, "impossible encoding");
     Address ref_addr($mem$$Register);
-    z_color(_masm, this, $oldval_tmp$$Register, $oldval$$Register, $oldval_tmp$$Register);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->z_color(&_masm, $oldval_tmp$$Register, $oldval$$Register, $oldval_tmp$$Register);
     z_store_barrier(_masm, this, ref_addr, $newval$$Register, $newval_tmp$$Register, rscratch2, true /* is_atomic */);
     __ cmpxchg($mem$$Register, $oldval_tmp$$Register, $newval_tmp$$Register, Assembler::xword,
                true /* acquire */, true /* release */, false /* weak */, noreg);
@@ -234,11 +226,12 @@ instruct zCompareAndExchangeP(iRegPNoSp res, indirect mem, iRegP oldval, iRegP n
   ins_encode %{
     guarantee($mem$$index == -1 && $mem$$disp == 0, "impossible encoding");
     Address ref_addr($mem$$Register);
-    z_color(_masm, this, $oldval_tmp$$Register, $oldval$$Register, $oldval_tmp$$Register);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->z_color(&_masm, $oldval_tmp$$Register, $oldval$$Register, $oldval_tmp$$Register);
     z_store_barrier(_masm, this, ref_addr, $newval$$Register, $newval_tmp$$Register, rscratch2, true /* is_atomic */);
     __ cmpxchg($mem$$Register, $oldval_tmp$$Register, $newval_tmp$$Register, Assembler::xword,
                false /* acquire */, true /* release */, false /* weak */, $res$$Register);
-    z_uncolor(_masm, this, $res$$Register);
+    bs_asm->z_uncolor(&_masm, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
@@ -257,11 +250,12 @@ instruct zCompareAndExchangePAcq(iRegPNoSp res, indirect mem, iRegP oldval, iReg
   ins_encode %{
     guarantee($mem$$index == -1 && $mem$$disp == 0, "impossible encoding");
     Address ref_addr($mem$$Register);
-    z_color(_masm, this, $oldval_tmp$$Register, $oldval$$Register, $oldval_tmp$$Register);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->z_color(&_masm, $oldval_tmp$$Register, $oldval$$Register, $oldval_tmp$$Register);
     z_store_barrier(_masm, this, ref_addr, $newval$$Register, $newval_tmp$$Register, rscratch2, true /* is_atomic */);
     __ cmpxchg($mem$$Register, $oldval_tmp$$Register, $newval_tmp$$Register, Assembler::xword,
                true /* acquire */, true /* release */, false /* weak */, $res$$Register);
-    z_uncolor(_masm, this, $res$$Register);
+    bs_asm->z_uncolor(&_masm, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
@@ -279,7 +273,8 @@ instruct zGetAndSetP(indirect mem, iRegP newv, iRegPNoSp prev, rFlagsReg cr) %{
   ins_encode %{
     z_store_barrier(_masm, this, Address($mem$$Register), $newv$$Register, $prev$$Register, rscratch2, true /* is_atomic */);
     __ atomic_xchg($prev$$Register, $prev$$Register, $mem$$Register);
-    z_uncolor(_masm, this, $prev$$Register);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->z_uncolor(&_masm, $prev$$Register);
   %}
 
   ins_pipe(pipe_serial);
@@ -297,7 +292,8 @@ instruct zGetAndSetPAcq(indirect mem, iRegP newv, iRegPNoSp prev, rFlagsReg cr) 
   ins_encode %{
     z_store_barrier(_masm, this, Address($mem$$Register), $newv$$Register, $prev$$Register, rscratch2, true /* is_atomic */);
     __ atomic_xchgal($prev$$Register, $prev$$Register, $mem$$Register);
-    z_uncolor(_masm, this, $prev$$Register);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->z_uncolor(&_masm, $prev$$Register);
   %}
 
   ins_pipe(pipe_serial);

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.hpp
@@ -180,6 +180,12 @@ public:
   void patch_barriers();
 
   void check_oop(MacroAssembler* masm, Register obj, Register tmp1, Register tmp2, Label& error);
+
+  void z_color(MacroAssembler* masm, Register ref) const;
+
+  void z_uncolor(MacroAssembler* masm, Register ref) const;
+
+  void check_color(MacroAssembler* masm, Register ref) const;
 };
 
 #endif // CPU_X86_GC_Z_ZBARRIERSETASSEMBLER_X86_HPP

--- a/src/hotspot/cpu/x86/gc/z/z_x86_64.ad
+++ b/src/hotspot/cpu/x86/gc/z/z_x86_64.ad
@@ -34,26 +34,14 @@ source %{
 #include "c2_intelJccErratum_x86.hpp"
 #include "gc/z/zBarrierSetAssembler.hpp"
 
-static void z_color(MacroAssembler& _masm, const MachNode* node, Register ref) {
-  __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatLoadGoodBeforeShl);
-  __ shlq(ref, barrier_Relocation::unpatched);
-  __ orq_imm32(ref, barrier_Relocation::unpatched);
-  __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatStoreGoodAfterOr);
-}
-
-static void z_uncolor(MacroAssembler& _masm, const MachNode* node, Register ref) {
-  __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatLoadGoodBeforeShl);
-  __ shrq(ref, barrier_Relocation::unpatched);
-}
-
 static void z_keep_alive_load_barrier(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register ref) {
-  __ Assembler::testl(ref, barrier_Relocation::unpatched);
-  __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatMarkBadAfterTest);
+  ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+  bs_asm->check_color(&_masm, ref);
 
   ZLoadBarrierStubC2* const stub = ZLoadBarrierStubC2::create(node, ref_addr, ref);
   __ jcc(Assembler::notEqual, *stub->entry());
 
-  z_uncolor(_masm, node, ref);
+  bs_asm->z_uncolor(&_masm, ref);
 
   __ bind(*stub->continuation());
 }
@@ -69,7 +57,8 @@ static void z_load_barrier(MacroAssembler& _masm, const MachNode* node, Address 
     return;
   }
 
-  z_uncolor(_masm, node, ref);
+  ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+  bs_asm->z_uncolor(&_masm, ref);
   if (node->barrier_data() == ZBarrierElided) {
     return;
   }
@@ -81,16 +70,16 @@ static void z_load_barrier(MacroAssembler& _masm, const MachNode* node, Address 
 
 static void z_store_barrier(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register rnew_zaddress, Register rnew_zpointer, bool is_atomic) {
   Assembler::InlineSkippedInstructionsCounter skipped_counter(&_masm);
+  ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
   if (node->barrier_data() == ZBarrierElided) {
     if (rnew_zaddress != noreg) {
       // noreg means null; no need to color
       __ movptr(rnew_zpointer, rnew_zaddress);
-      z_color(_masm, node, rnew_zpointer);
+      bs_asm->z_color(&_masm, rnew_zpointer);
     }
   } else {
     bool is_native = (node->barrier_data() & ZBarrierNative) != 0;
     ZStoreBarrierStubC2* const stub = ZStoreBarrierStubC2::create(node, ref_addr, rnew_zaddress, rnew_zpointer, is_native, is_atomic);
-    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
     bs_asm->store_barrier_fast(&_masm, ref_addr, rnew_zaddress, rnew_zpointer, true /* in_nmethod */, is_atomic, *stub->entry(), *stub->continuation());
   }
 }
@@ -181,10 +170,11 @@ instruct zCompareAndExchangeP(indirect mem, no_rax_RegP newval, rRegP tmp, rax_R
     assert_different_registers($oldval$$Register, $newval$$Register);
     const Address mem_addr = Address($mem$$Register, 0);
     z_store_barrier(_masm, this, mem_addr, $newval$$Register, $tmp$$Register, true /* is_atomic */);
-    z_color(_masm, this, $oldval$$Register);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->z_color(&_masm, $oldval$$Register);
     __ lock();
     __ cmpxchgptr($tmp$$Register, mem_addr);
-    z_uncolor(_masm, this, $oldval$$Register);
+    bs_asm->z_uncolor(&_masm, $oldval$$Register);
   %}
 
   ins_pipe(pipe_cmpxchg);
@@ -205,7 +195,8 @@ instruct zCompareAndSwapP(rRegI res, indirect mem, rRegP newval, rRegP tmp, rax_
     assert_different_registers($oldval$$Register, $mem$$Register);
     const Address mem_addr = Address($mem$$Register, 0);
     z_store_barrier(_masm, this, mem_addr, $newval$$Register, $tmp$$Register, true /* is_atomic */);
-    z_color(_masm, this, $oldval$$Register);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->z_color(&_masm, $oldval$$Register);
     __ lock();
     __ cmpxchgptr($tmp$$Register, mem_addr);
     __ setb(Assembler::equal, $res$$Register);
@@ -228,7 +219,8 @@ instruct zXChgP(indirect mem, rRegP newval, rRegP tmp, rFlagsReg cr) %{
     z_store_barrier(_masm, this, mem_addr, $newval$$Register, $tmp$$Register, true /* is_atomic */);
     __ movptr($newval$$Register, $tmp$$Register);
     __ xchgptr($newval$$Register, mem_addr);
-    z_uncolor(_masm, this, $newval$$Register);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->z_uncolor(&_masm, $newval$$Register);
   %}
 
   ins_pipe(pipe_cmpxchg);


### PR DESCRIPTION
Hi  @stefank 

I reused the code about z_color, z_uncolor and check_color for LoongArch port, then I also implemented it for x86_64 and aarch64. And as you suggested I moved ZGC-specific code back into files that belong to ZGC.

x86_64 fastdebug jtreg tier1:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
>> jtreg:test/hotspot/jtreg:tier1                     1682  1678     4     0 <<
>> jtreg:test/jdk:tier1                               2232  2227     3     2 <<
>> jtreg:test/langtools:tier1                         4361  4344     9     8 <<
   jtreg:test/jaxp:tier1                                 0     0     0     0   
   jtreg:test/lib-test:tier1                            27    27     0     0   
==============================
```

aarch64 fastdebug hotspot:tier1:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
>> jtreg:test/hotspot/jtreg:tier1                     1687  1655    32     0 <<
==============================
```

Please review my patch.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/zgc pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/zgc pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/zgc/pull/7.diff">https://git.openjdk.org/zgc/pull/7.diff</a>

</details>
