### PR TITLE
Fix for failing string-table test

### DIFF
--- a/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
+++ b/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
@@ -81,9 +81,11 @@ public class StringTableCleaningTest {
     // All G1 pauses except Cleanup do weak reference clearing.
     private static final String g1Suffix = "Pause(?! Cleanup)";
 
-    // Suffix for ZGC. Only major collections clean the string table.
-    private static final String zStartSuffix = "Major Garbage Collection \\(.*\\)$";
-    private static final String zEndSuffix = "Major Garbage Collection \\(.*\\) .*->.*$";
+    // For ZGC only major collections clean the string table. ZGC prints the
+    // start message without using the start tag, hence the special prefix.
+    private static final String zStartPrefix = gcPrefix + gcMiddle;
+    private static final String zStartSuffix = "Major Collection \\(.*\\)$";
+    private static final String zEndSuffix = "Major Collection \\(.*\\) .*->.*$";
 
     // Suffix for Shenandoah.
     private static final String shenSuffix = "Concurrent weak roots";
@@ -94,7 +96,7 @@ public class StringTableCleaningTest {
         } else if (GC.G1.isSelected()) {
             return gcStartPrefix + g1Suffix;
         } else if (GC.Z.isSelected()) {
-            return gcStartPrefix + zStartSuffix;
+            return zStartPrefix + zStartSuffix;
         } else if (GC.Shenandoah.isSelected()) {
             return gcStartPrefix + shenSuffix;
         } else {


### PR DESCRIPTION
Please review this fix for a failing test that expects ZGC logging to look a certain way. 

Updated the log-messages to match the current state of things.