### PR TITLE
Generational ZGC on linux RISCV64

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -858,10 +858,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
       __ decode_heap_oop(dest->as_register());
     }
 
-    if (!UseZGC) {
-      // Load barrier has not yet been applied, so ZGC can't verify the oop here
-      __ verify_oop(dest->as_register());
-    }
+    __ verify_oop(dest->as_register());
   }
 }
 
@@ -1264,10 +1261,13 @@ void LIR_Assembler::emit_compare_and_swap(LIR_OpCompareAndSwap* op) {
     if (UseCompressedOops) {
       Register tmp1 = op->tmp1()->as_register();
       assert(op->tmp1()->is_valid(), "must be");
+      Register tmp2 = op->tmp2()->as_register();
+      assert(op->tmp2()->is_valid(), "must be");
+
       __ encode_heap_oop(tmp1, cmpval);
       cmpval = tmp1;
-      __ encode_heap_oop(t1, newval);
-      newval = t1;
+      __ encode_heap_oop(tmp2, newval);
+      newval = tmp2;
       caswu(addr, newval, cmpval);
     } else {
       casl(addr, newval, cmpval);
@@ -1276,6 +1276,11 @@ void LIR_Assembler::emit_compare_and_swap(LIR_OpCompareAndSwap* op) {
     casw(addr, newval, cmpval);
   } else {
     casl(addr, newval, cmpval);
+  }
+
+  if (op->result_opr()->is_valid()) {
+    assert(op->result_opr()->is_register(), "need a register");
+    __ mv(as_reg(op->result_opr()), t0); // cas result in t0, and 0 for success
   }
 }
 

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,6 +117,86 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
     default: Unimplemented();
   }
 
+}
+
+void BarrierSetAssembler::copy_load_at(MacroAssembler* masm,
+                                       DecoratorSet decorators,
+                                       BasicType type,
+                                       size_t bytes,
+                                       Register dst,
+                                       Address src,
+                                       Register tmp) {
+  if (bytes == 1) {
+    __ lbu(dst, src);
+  } else if (bytes == 2) {
+    __ lhu(dst, src);
+  } else if (bytes == 4) {
+    __ lwu(dst, src);
+  } else if (bytes == 8) {
+    __ ld(dst, src);
+  } else {
+    // Not the right size
+    ShouldNotReachHere();
+  }
+  if ((decorators & ARRAYCOPY_CHECKCAST) != 0 && UseCompressedOops) {
+    __ decode_heap_oop(dst);
+  }
+}
+
+void BarrierSetAssembler::copy_store_at(MacroAssembler* masm,
+                                        DecoratorSet decorators,
+                                        BasicType type,
+                                        size_t bytes,
+                                        Address dst,
+                                        Register src,
+                                        Register tmp1,
+                                        Register tmp2,
+                                        Register tmp3) {
+  if ((decorators & ARRAYCOPY_CHECKCAST) != 0 && UseCompressedOops) {
+    __ encode_heap_oop(src);
+  }
+
+  if (bytes == 1) {
+    __ sb(src, dst);
+  } else if (bytes == 2) {
+    __ sh(src, dst);
+  } else if (bytes == 4) {
+    __ sw(src, dst);
+  } else if (bytes == 8) {
+    __ sd(src, dst);
+  } else {
+    // Not the right size
+    ShouldNotReachHere();
+  }
+}
+
+void BarrierSetAssembler::copy_load_at(MacroAssembler* masm,
+                                       DecoratorSet decorators,
+                                       BasicType type,
+                                       size_t bytes,
+                                       FloatRegister dst1,
+                                       FloatRegister dst2,
+                                       Address src,
+                                       Register tmp1,
+                                       Register tmp2,
+                                       FloatRegister vec_tmp) {
+  Unimplemented();
+}
+
+void BarrierSetAssembler::copy_store_at(MacroAssembler* masm,
+                                        DecoratorSet decorators,
+                                        BasicType type,
+                                        size_t bytes,
+                                        Address dst,
+                                        FloatRegister src1,
+                                        FloatRegister src2,
+                                        Register tmp1,
+                                        Register tmp2,
+                                        Register tmp3,
+                                        FloatRegister vec_tmp1,
+                                        FloatRegister vec_tmp2,
+                                        FloatRegister vec_tmp3) {
+  Unimplemented();
 }
 
 void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
@@ -307,4 +387,19 @@ void BarrierSetAssembler::c2i_entry_barrier(MacroAssembler* masm) {
 
   __ far_jump(RuntimeAddress(SharedRuntime::get_handle_wrong_method_stub()));
   __ bind(method_live);
+}
+
+void BarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register tmp1, Register tmp2, Label& error) {
+  // Check if the oop is in the right area of memory
+  __ mv(tmp2, (intptr_t) Universe::verify_oop_mask());
+  __ andr(tmp1, obj, tmp2);
+  __ mv(tmp2, (intptr_t) Universe::verify_oop_bits());
+
+  // Compare tmp1 and tmp2.
+  __ xorr(tmp1, tmp1, tmp2);
+  __ bnez(tmp1, error);
+
+  // Make sure klass is 'reasonable', which is not zero.
+  __ load_klass(obj, obj, tmp1); // get klass
+  __ beqz(obj, error);           // if klass is NULL it is broken
 }

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,50 @@ public:
                                   Register src, Register dst, Register count, RegSet saved_regs) {}
   virtual void arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
                                   Register start, Register count, Register tmp, RegSet saved_regs) {}
+
+  virtual void copy_load_at(MacroAssembler* masm,
+                            DecoratorSet decorators,
+                            BasicType type,
+                            size_t bytes,
+                            Register dst,
+                            Address src,
+                            Register tmp);
+
+  virtual void copy_store_at(MacroAssembler* masm,
+                             DecoratorSet decorators,
+                             BasicType type,
+                             size_t bytes,
+                             Address dst,
+                             Register src,
+                             Register tmp1,
+                             Register tmp2,
+                             Register tmp3);
+
+  virtual void copy_load_at(MacroAssembler* masm,
+                            DecoratorSet decorators,
+                            BasicType type,
+                            size_t bytes,
+                            FloatRegister dst1,
+                            FloatRegister dst2,
+                            Address src,
+                            Register tmp1,
+                            Register tmp2,
+                            FloatRegister vec_tmp);
+
+  virtual void copy_store_at(MacroAssembler* masm,
+                             DecoratorSet decorators,
+                             BasicType type,
+                             size_t bytes,
+                             Address dst,
+                             FloatRegister src1,
+                             FloatRegister src2,
+                             Register tmp1,
+                             Register tmp2,
+                             Register tmp3,
+                             FloatRegister vec_tmp1,
+                             FloatRegister vec_tmp2,
+                             FloatRegister vec_tmp3);
+
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register dst, Address src, Register tmp1, Register tmp2);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
@@ -73,6 +117,8 @@ public:
 
   virtual void nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation, Label* guard);
   virtual void c2i_entry_barrier(MacroAssembler* masm);
+
+  virtual void check_oop(MacroAssembler* masm, Register obj, Register tmp1, Register tmp2, Label& error);
 
   virtual bool supports_instruction_patching() {
     NMethodPatchingType patching_type = nmethod_patching_type();

--- a/src/hotspot/cpu/riscv/gc/z/zAddress_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zAddress_riscv.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +23,87 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/shared/gcLogPrecious.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "gc/z/zAddress.hpp"
+#include "gc/z/zBarrierSetAssembler.hpp"
+#include "gc/z/zGlobals.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/os.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/powerOfTwo.hpp"
+
+#ifdef LINUX
+#include <sys/mman.h>
+#endif // LINUX
+
+// Default value if probe is not implemented for a certain platform: 128TB
+static const size_t DEFAULT_MAX_ADDRESS_BIT = 47;
+// Minimum value returned, if probing fails: 64GB
+static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;
+
+static size_t probe_valid_max_address_bit() {
+#ifdef LINUX
+  size_t max_address_bit = 0;
+  const size_t page_size = os::vm_page_size();
+  for (size_t i = DEFAULT_MAX_ADDRESS_BIT; i > MINIMUM_MAX_ADDRESS_BIT; --i) {
+    const uintptr_t base_addr = ((uintptr_t) 1U) << i;
+    if (msync((void*)base_addr, page_size, MS_ASYNC) == 0) {
+      // msync suceeded, the address is valid, and maybe even already mapped.
+      max_address_bit = i;
+      break;
+    }
+    if (errno != ENOMEM) {
+      // Some error occured. This should never happen, but msync
+      // has some undefined behavior, hence ignore this bit.
+#ifdef ASSERT
+      fatal("Received '%s' while probing the address space for the highest valid bit", os::errno_name(errno));
+#else // ASSERT
+      log_warning_p(gc)("Received '%s' while probing the address space for the highest valid bit", os::errno_name(errno));
+#endif // ASSERT
+      continue;
+    }
+    // Since msync failed with ENOMEM, the page might not be mapped.
+    // Try to map it, to see if the address is valid.
+    void* const result_addr = mmap((void*) base_addr, page_size, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0);
+    if (result_addr != MAP_FAILED) {
+      munmap(result_addr, page_size);
+    }
+    if ((uintptr_t) result_addr == base_addr) {
+      // address is valid
+      max_address_bit = i;
+      break;
+    }
+  }
+  if (max_address_bit == 0) {
+    // probing failed, allocate a very high page and take that bit as the maximum
+    const uintptr_t high_addr = ((uintptr_t) 1U) << DEFAULT_MAX_ADDRESS_BIT;
+    void* const result_addr = mmap((void*) high_addr, page_size, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0);
+    if (result_addr != MAP_FAILED) {
+      max_address_bit = BitsPerSize_t - count_leading_zeros((size_t) result_addr) - 1;
+      munmap(result_addr, page_size);
+    }
+  }
+  log_info_p(gc, init)("Probing address space for the highest valid bit: " SIZE_FORMAT, max_address_bit);
+  return MAX2(max_address_bit, MINIMUM_MAX_ADDRESS_BIT);
+#else // LINUX
+  return DEFAULT_MAX_ADDRESS_BIT;
+#endif // LINUX
+}
 
 size_t ZPlatformAddressOffsetBits() {
-  Unimplemented();
-  return {};
+  const static size_t valid_max_address_offset_bits = probe_valid_max_address_bit() + 1;
+  const size_t max_address_offset_bits = valid_max_address_offset_bits - 3;
+  const size_t min_address_offset_bits = max_address_offset_bits - 2;
+  const size_t address_offset = round_up_power_of_2(MaxHeapSize * ZVirtualToPhysicalRatio);
+  const size_t address_offset_bits = log2i_exact(address_offset);
+  return clamp(address_offset_bits, min_address_offset_bits, max_address_offset_bits);
 }
 
 size_t ZPlatformAddressHeapBaseShift() {
-  Unimplemented();
-  return {};
+  return ZPlatformAddressOffsetBits();
 }
 
 void ZGlobalsPointers::pd_set_good_masks() {
-  Unimplemented();
+  BarrierSetAssembler::clear_patching_epoch();
 }

--- a/src/hotspot/cpu/riscv/gc/z/zAddress_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/gc/z/zAddress_riscv.inline.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +28,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 inline uintptr_t ZPointer::remap_bits(uintptr_t colored) {
-  return (colored ^ ZPointerRemappedMask) & ZPointerRemappedMask;
+  return colored & ZPointerRemappedMask;
 }
 
 inline constexpr int ZPointer::load_shift_lookup(uintptr_t value) {

--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,14 @@
 #include "asm/macroAssembler.inline.hpp"
 #include "code/codeBlob.hpp"
 #include "code/vmreg.inline.hpp"
+#include "gc/z/zAddress.hpp"
 #include "gc/z/zBarrier.inline.hpp"
 #include "gc/z/zBarrierSet.hpp"
 #include "gc/z/zBarrierSetAssembler.hpp"
 #include "gc/z/zBarrierSetRuntime.hpp"
 #include "gc/z/zThreadLocalData.hpp"
 #include "memory/resourceArea.hpp"
+#include "runtime/jniHandles.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/macros.hpp"
@@ -43,6 +45,7 @@
 #endif // COMPILER1
 #ifdef COMPILER2
 #include "gc/z/c2/zBarrierSetC2.hpp"
+#include "opto/output.hpp"
 #endif // COMPILER2
 
 #ifdef PRODUCT
@@ -54,14 +57,305 @@
 #undef __
 #define __ masm->
 
+// Helper for saving and restoring registers across a runtime call that does
+// not have any live vector registers.
+class ZRuntimeCallSpill {
+private:
+  MacroAssembler* _masm;
+  Register _result;
+
+  void save() {
+    MacroAssembler* masm = _masm;
+
+    __ enter();
+    if (_result != noreg) {
+      __ push_call_clobbered_registers_except(RegSet::of(_result));
+    } else {
+      __ push_call_clobbered_registers();
+    }
+  }
+
+  void restore() {
+    MacroAssembler* masm = _masm;
+
+    if (_result != noreg) {
+      // Make sure _result has the return value.
+      if (_result != x10) {
+        __ mv(_result, x10);
+      }
+
+      __ pop_call_clobbered_registers_except(RegSet::of(_result));
+    } else {
+      __ pop_call_clobbered_registers();
+    }
+    __ leave();
+  }
+
+public:
+  ZRuntimeCallSpill(MacroAssembler* masm, Register result)
+    : _masm(masm),
+      _result(result) {
+    save();
+  }
+
+  ~ZRuntimeCallSpill() {
+    restore();
+  }
+};
+
+void ZBarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register tmp1, Register tmp2, Label& error) {
+  // C1 calls verify_oop in the middle of barriers, before they have been uncolored
+  // and after being colored. Therefore, we must deal with colored oops as well.
+  Label done;
+  Label check_oop;
+  Label check_zaddress;
+  int color_bits = ZPointerRemappedShift + ZPointerRemappedBits;
+
+  uintptr_t shifted_base_start_mask = (UCONST64(1) << (ZAddressHeapBaseShift + color_bits + 1)) - 1;
+  uintptr_t shifted_base_end_mask = (UCONST64(1) << (ZAddressHeapBaseShift + 1)) - 1;
+  uintptr_t shifted_base_mask = shifted_base_start_mask ^ shifted_base_end_mask;
+
+  uintptr_t shifted_address_end_mask = (UCONST64(1) << (color_bits + 1)) - 1;
+  uintptr_t shifted_address_mask = shifted_base_end_mask ^ (uintptr_t)CONST64(-1);
+
+  // Check colored null
+  __ mv(tmp1, shifted_address_mask);
+  __ andr(tmp1, tmp1, obj);
+  __ beqz(tmp1, done);
+
+  // Check for zpointer
+  __ mv(tmp1, shifted_base_mask);
+  __ andr(tmp1, tmp1, obj);
+  __ beqz(tmp1, check_oop);
+
+  // Uncolor presumed zpointer
+  __ srli(obj, obj, ZPointerLoadShift);
+
+  __ j(check_zaddress);
+
+  __ bind(check_oop);
+
+  // Make sure klass is 'reasonable', which is not zero
+  __ load_klass(tmp1, obj, tmp2);
+  __ beqz(tmp1, error);
+
+  __ bind(check_zaddress);
+  // Check if the oop is the right area of memory
+  __ mv(tmp1, (intptr_t) Universe::verify_oop_mask());
+  __ andr(tmp1, tmp1, obj);
+  __ mv(obj, (intptr_t) Universe::verify_oop_bits());
+  __ bne(tmp1, obj, error);
+
+  __ bind(done);
+}
+
 void ZBarrierSetAssembler::load_at(MacroAssembler* masm,
                                    DecoratorSet decorators,
                                    BasicType type,
                                    Register dst,
                                    Address src,
                                    Register tmp1,
-                                   Register tmp_thread) {
-  Unimplemented();
+                                   Register tmp2) {
+  if (!ZBarrierSet::barrier_needed(decorators, type)) {
+    // Barrier not needed
+    BarrierSetAssembler::load_at(masm, decorators, type, dst, src, tmp1, tmp2);
+    return;
+  }
+
+  assert_different_registers(tmp1, tmp2, src.base(), noreg);
+  assert_different_registers(tmp1, tmp2, dst, noreg);
+  assert_different_registers(tmp2, t0);
+
+  Label done;
+  Label uncolor;
+
+  // Load bad mask into scratch register.
+  const bool on_non_strong =
+    (decorators & ON_WEAK_OOP_REF) != 0 ||
+    (decorators & ON_PHANTOM_OOP_REF) != 0;
+
+  if (on_non_strong) {
+    __ ld(tmp1, mark_bad_mask_from_thread(xthread));
+  } else {
+    __ ld(tmp1, load_bad_mask_from_thread(xthread));
+  }
+
+  __ la(tmp2, src);
+  __ ld(dst, tmp2);
+
+  // Test reference against bad mask. If mask bad, then we need to fix it up.
+  __ andr(tmp1, dst, tmp1);
+  __ beqz(tmp1, uncolor);
+
+  {
+    // Call VM
+    ZRuntimeCallSpill rsc(masm, dst);
+
+    if (c_rarg0 != dst) {
+      __ mv(c_rarg0, dst);
+    }
+    __ mv(c_rarg1, tmp2);
+
+    __ call_VM_leaf(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_addr(decorators), 2);
+  }
+
+  // Slow-path has already uncolored
+  __ j(done);
+
+  __ bind(uncolor);
+
+  // Remove the color bits
+  __ srli(dst, dst, ZPointerLoadShift);
+
+  __ bind(done);
+}
+
+void ZBarrierSetAssembler::store_barrier_fast(MacroAssembler* masm,
+                                              Address ref_addr,
+                                              Register rnew_zaddress,
+                                              Register rnew_zpointer,
+                                              Register rtmp,
+                                              bool in_nmethod,
+                                              bool is_atomic,
+                                              Label& medium_path,
+                                              Label& medium_path_continuation) const {
+  assert_different_registers(ref_addr.base(), rnew_zpointer, rtmp);
+  assert_different_registers(rnew_zaddress, rnew_zpointer, rtmp);
+
+  if (in_nmethod) {
+    if (is_atomic) {
+      __ lhu(rtmp, ref_addr);
+      // Atomic operations must ensure that the contents of memory are store-good before
+      // an atomic opertion can execute.
+      // A non-relocatable object could have spurious raw NULL pointers in its fields after
+      // getting promoted to the old generation.
+      __ relocate(barrier_Relocation::spec(), [&] {
+        __ li16u(rnew_zpointer, barrier_Relocation::unpatched);
+      }, ZBarrierRelocationFormatStoreGoodBits);
+      __ bne(rtmp, rnew_zpointer, medium_path, true /* is_far */);
+    } else {
+      __ ld(rtmp, ref_addr);
+      // Stores on relocatable objects never need to deal with raw NULL pointers in fields.
+      // Raw NULL pointers may only exists in the young generation, as they get pruned when
+      // the object is relocated to old. And no pre-write barrier needs to perform any action
+      // in the young generation.
+      __ relocate(barrier_Relocation::spec(), [&] {
+        __ li16u(rnew_zpointer, barrier_Relocation::unpatched);
+      }, ZBarrierRelocationFormatStoreBadMask);
+      __ andr(rtmp, rtmp, rnew_zpointer);
+      __ bnez(rtmp, medium_path, true /* is_far */);
+    }
+    __ bind(medium_path_continuation);
+    __ relocate(barrier_Relocation::spec(), [&] {
+      __ li16u(rtmp, barrier_Relocation::unpatched);
+    }, ZBarrierRelocationFormatStoreGoodBits);
+    __ slli(rnew_zpointer, rnew_zaddress, ZPointerLoadShift);
+    __ orr(rnew_zpointer, rnew_zpointer, rtmp);
+  } else {
+    assert(!is_atomic, "atomic outside of nmethods not supported");
+    __ la(rtmp, ref_addr);
+    __ ld(rtmp, rtmp);
+    __ ld(rnew_zpointer, Address(xthread, ZThreadLocalData::store_bad_mask_offset()));
+    __ andr(rtmp, rtmp, rnew_zpointer);
+    __ bnez(rtmp, medium_path, true /* is_far */);
+    __ bind(medium_path_continuation);
+    if (rnew_zaddress == noreg) {
+      __ mv(rnew_zpointer, zr);
+    } else {
+      __ mv(rnew_zpointer, rnew_zaddress);
+    }
+
+    // Load the current good shift, and add the color bits
+    __ slli(rnew_zpointer, rnew_zpointer, ZPointerLoadShift);
+    __ ld(rtmp, Address(xthread, ZThreadLocalData::store_good_mask_offset()));
+    __ orr(rnew_zpointer, rnew_zpointer, rtmp);
+  }
+}
+
+static void store_barrier_buffer_add(MacroAssembler* masm,
+                                     Address ref_addr,
+                                     Register tmp1,
+                                     Register tmp2,
+                                     Label& slow_path) {
+  Address buffer(xthread, ZThreadLocalData::store_barrier_buffer_offset());
+  assert_different_registers(ref_addr.base(), tmp1, tmp2);
+
+  __ ld(tmp1, buffer);
+
+  // Combined pointer bump and check if the buffer is disabled or full
+  __ ld(tmp2, Address(tmp1, ZStoreBarrierBuffer::current_offset()));
+  __ beqz(tmp2, slow_path);
+
+  // Bump the pointer
+  __ sub(tmp2, tmp2, sizeof(ZStoreBarrierEntry));
+  __ sd(tmp2, Address(tmp1, ZStoreBarrierBuffer::current_offset()));
+
+  // Compute the buffer entry address
+  __ la(tmp2, Address(tmp2, ZStoreBarrierBuffer::buffer_offset()));
+  __ add(tmp2, tmp2, tmp1);
+
+  // Compute and log the store address
+  __ la(tmp1, ref_addr);
+  __ sd(tmp1, Address(tmp2, in_bytes(ZStoreBarrierEntry::p_offset())));
+
+  // Load and log the prev value
+  __ ld(tmp1, tmp1);
+  __ sd(tmp1, Address(tmp2, in_bytes(ZStoreBarrierEntry::prev_offset())));
+
+  // Log pc for debugging
+  __ auipc(tmp1, 0);
+  __ sd(tmp1, Address(tmp2, in_bytes(ZStoreBarrierEntry::pc_offset())));
+}
+
+void ZBarrierSetAssembler::store_barrier_medium(MacroAssembler* masm,
+                                                Address ref_addr,
+                                                Register rtmp1,
+                                                Register rtmp2,
+                                                Register rtmp3,
+                                                bool is_native,
+                                                bool is_atomic,
+                                                Label& medium_path_continuation,
+                                                Label& slow_path,
+                                                Label& slow_path_continuation) const {
+  assert_different_registers(ref_addr.base(), rtmp1, rtmp2, rtmp3);
+
+  // The reason to end up in the medium path is that the pre-value was not 'good'.
+  if (is_native) {
+    __ j(slow_path);
+    __ bind(slow_path_continuation);
+    __ j(medium_path_continuation);
+  } else if (is_atomic) {
+    // Atomic accesses can get to the medium fast path because the value was a
+    // raw NULL value. If it was not NULL, then there is no doubt we need to take a slow path.
+
+    __ la(rtmp2, ref_addr);
+    __ ld(rtmp1, rtmp2);
+    __ bnez(rtmp1, slow_path);
+
+    // If we get this far, we know there is a young raw NULL value in the field.
+    __ relocate(barrier_Relocation::spec(), [&] {
+      __ li16u(rtmp1, barrier_Relocation::unpatched);
+    }, ZBarrierRelocationFormatStoreGoodBits);
+    __ cmpxchg_weak(rtmp2, zr, rtmp1,
+                    Assembler::int64,
+                    Assembler::relaxed /* acquire */, Assembler::relaxed /* release */,
+                    rtmp3);
+    __ beqz(rtmp3, slow_path);
+    __ bind(slow_path_continuation);
+    __ j(medium_path_continuation);
+  } else {
+    // A non-atomic relocatable object wont't get to the medium fast path due to a
+    // raw NULL in the young generation. We only get here because the field is bad.
+    // In this path we don't need any self healing, so we can avoid a runtime call
+    // most of the time by buffering the store barrier to be applied lazily.
+    store_barrier_buffer_add(masm,
+                             ref_addr,
+                             rtmp1,
+                             rtmp2,
+                             slow_path);
+    __ bind(slow_path_continuation);
+    __ j(medium_path_continuation);
+  }
 }
 
 void ZBarrierSetAssembler::store_at(MacroAssembler* masm,
@@ -72,8 +366,103 @@ void ZBarrierSetAssembler::store_at(MacroAssembler* masm,
                                     Register tmp1,
                                     Register tmp2,
                                     Register tmp3) {
-  Unimplemented();
+  if (!ZBarrierSet::barrier_needed(decorators, type)) {
+    BarrierSetAssembler::store_at(masm, decorators, type, dst, val, tmp1, tmp2, tmp3);
+    return;
+  }
+
+  bool dest_uninitialized = (decorators & IS_DEST_UNINITIALIZED) != 0;
+
+  assert_different_registers(val, tmp1, dst.base());
+
+  if (dest_uninitialized) {
+    if (val == noreg) {
+      __ mv(tmp1, zr);
+    } else {
+      __ mv(tmp1, val);
+    }
+    // Add the color bits
+    __ slli(tmp1, tmp1, ZPointerLoadShift);
+    __ ld(tmp2, Address(xthread, ZThreadLocalData::store_good_mask_offset()));
+    __ orr(tmp1, tmp2, tmp1);
+  } else {
+    Label done;
+    Label medium;
+    Label medium_continuation;
+    Label slow;
+    Label slow_continuation;
+    store_barrier_fast(masm, dst, val, tmp1, tmp2, false, false, medium, medium_continuation);
+
+    __ j(done);
+    __ bind(medium);
+    store_barrier_medium(masm,
+                         dst,
+                         tmp1,
+                         tmp2,
+                         noreg /* tmp3 */,
+                         false /* is_native */,
+                         false /* is_atomic */,
+                         medium_continuation,
+                         slow,
+                         slow_continuation);
+
+    __ bind(slow);
+    {
+      // Call VM
+      ZRuntimeCallSpill rcs(masm, noreg);
+      __ la(c_rarg0, dst);
+      __ MacroAssembler::call_VM_leaf(ZBarrierSetRuntime::store_barrier_on_oop_field_without_healing_addr(), 1);
+    }
+
+    __ j(slow_continuation);
+    __ bind(done);
+  }
+
+  // Store value
+  BarrierSetAssembler::store_at(masm, decorators, type, dst, tmp1, tmp2, tmp3, noreg);
 }
+
+class ZCopyRuntimeCallSpill {
+private:
+  MacroAssembler* _masm;
+  Register _result;
+
+  void save() {
+    MacroAssembler* masm = _masm;
+
+    __ enter();
+    if (_result != noreg) {
+      __ push_call_clobbered_registers_except(RegSet::of(_result));
+    } else {
+      __ push_call_clobbered_registers();
+    }
+  }
+
+  void restore() {
+    MacroAssembler* masm = _masm;
+
+    if (_result != noreg) {
+      if (_result != x10) {
+        __ mv(_result, x10);
+      }
+      __ pop_call_clobbered_registers_except(RegSet::of(_result));
+    } else {
+      __ pop_call_clobbered_registers();
+    }
+    __ leave();
+  }
+
+public:
+  ZCopyRuntimeCallSpill(MacroAssembler* masm, Register result)
+    : _masm(masm),
+      _result(result) {
+    save();
+  }
+
+  ~ZCopyRuntimeCallSpill() {
+    restore();
+  }
+};
 
 void ZBarrierSetAssembler::arraycopy_prologue(MacroAssembler* masm,
                                               DecoratorSet decorators,
@@ -82,60 +471,161 @@ void ZBarrierSetAssembler::arraycopy_prologue(MacroAssembler* masm,
                                               Register dst,
                                               Register count,
                                               RegSet saved_regs) {
-  Unimplemented();
+}
+
+static void copy_load_barrier(MacroAssembler* masm,
+                              Register ref,
+                              Address src,
+                              Register tmp) {
+  Label done;
+
+  __ ld(tmp, Address(xthread, ZThreadLocalData::load_bad_mask_offset()));
+
+  // Test reference against bad mask. If mask bad, then we need to fix it up
+  __ andr(tmp, ref, tmp);
+  __ beqz(tmp, done);
+
+  {
+    // Call VM
+    ZCopyRuntimeCallSpill rsc(masm, ref);
+
+    __ la(c_rarg1, src);
+
+    if (c_rarg0 != ref) {
+      __ mv(c_rarg0, ref);
+    }
+
+    __ call_VM_leaf(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_addr(IN_HEAP | ON_STRONG_OOP_REF), 2);
+  }
+
+  // Slow-path has uncolored; revert
+  __ slli(ref, ref, ZPointerLoadShift);
+
+  __ bind(done);
+}
+
+static void copy_store_barrier(MacroAssembler* masm,
+                               Register pre_ref,
+                               Register new_ref,
+                               Address src,
+                               Register tmp1,
+                               Register tmp2) {
+  Label done;
+  Label slow;
+
+  // Test reference against bad mask. If mask bad, then we need to fix it up.
+  __ ld(tmp1, Address(xthread, ZThreadLocalData::store_bad_mask_offset()));
+  __ andr(tmp1, pre_ref, tmp1);
+  __ beqz(tmp1, done);
+
+  store_barrier_buffer_add(masm, src, tmp1, tmp2, slow);
+  __ j(done);
+
+  __ bind(slow);
+  {
+    // Call VM
+    ZCopyRuntimeCallSpill rcs(masm, noreg);
+
+    __ la(c_rarg0, src);
+
+    __ call_VM_leaf(ZBarrierSetRuntime::store_barrier_on_oop_field_without_healing_addr(), 1);
+  }
+
+  __ bind(done);
+
+  if (new_ref != noreg) {
+    // Set store-good color, replacing whatever color was there before
+    __ ld(tmp1, Address(xthread, ZThreadLocalData::store_good_mask_offset()));
+    __ srli(new_ref, new_ref, 16);
+    __ slli(new_ref, new_ref, 16);
+    __ orr(new_ref, new_ref, tmp1);
+  }
 }
 
 void ZBarrierSetAssembler::copy_load_at(MacroAssembler* masm,
-                  DecoratorSet decorators,
-                  BasicType type,
-                  size_t bytes,
-                  Register dst1,
-                  Register dst2,
-                  Address src,
-                  Register tmp) {
+                                        DecoratorSet decorators,
+                                        BasicType type,
+                                        size_t bytes,
+                                        Register dst,
+                                        Address src,
+                                        Register tmp) {
+  if (!is_reference_type(type)) {
+    BarrierSetAssembler::copy_load_at(masm, decorators, type, bytes, dst, src, noreg);
+    return;
+  }
+
+  BarrierSetAssembler::copy_load_at(masm, decorators, type, bytes, dst, src, noreg);
+
+  assert(bytes == 8, "unsupported copy step");
+  copy_load_barrier(masm, dst, src, tmp);
+
+  if ((decorators & ARRAYCOPY_CHECKCAST) != 0) {
+    __ srli(dst, dst, ZPointerLoadShift);
+  }
+}
+
+void ZBarrierSetAssembler::copy_store_at(MacroAssembler* masm,
+                                         DecoratorSet decorators,
+                                         BasicType type,
+                                         size_t bytes,
+                                         Address dst,
+                                         Register src,
+                                         Register tmp1,
+                                         Register tmp2,
+                                         Register tmp3) {
+  if (!is_reference_type(type)) {
+    BarrierSetAssembler::copy_store_at(masm, decorators, type, bytes, dst, src, noreg, noreg, noreg);
+    return;
+  }
+
+  if ((decorators & ARRAYCOPY_CHECKCAST) != 0) {
+    __ slli(src, src, ZPointerLoadShift);
+  }
+
+  bool is_dest_uninitialized = (decorators & IS_DEST_UNINITIALIZED) != 0;
+
+  assert(bytes == 8, "unsupported copy step");
+  if (is_dest_uninitialized) {
+    __ ld(tmp1, Address(xthread, ZThreadLocalData::store_good_mask_offset()));
+    __ srli(src, src, 16);
+    __ slli(src, src, 16);
+    __ orr(src, src, tmp1);
+  } else {
+    // Store barrier pre values and color new values
+    __ ld(tmp1, dst);
+    copy_store_barrier(masm, tmp1, src, dst, tmp2, tmp3);
+  }
+
+  // Store new values
+  BarrierSetAssembler::copy_store_at(masm, decorators, type, bytes, dst, src, noreg, noreg, noreg);
+}
+
+void ZBarrierSetAssembler::copy_load_at(MacroAssembler* masm,
+                                        DecoratorSet decorators,
+                                        BasicType type,
+                                        size_t bytes,
+                                        FloatRegister dst1,
+                                        FloatRegister dst2,
+                                        Address src,
+                                        Register tmp1,
+                                        Register tmp2,
+                                        FloatRegister vec_tmp) {
   Unimplemented();
 }
 
 void ZBarrierSetAssembler::copy_store_at(MacroAssembler* masm,
-                  DecoratorSet decorators,
-                  BasicType type,
-                  size_t bytes,
-                  Address dst,
-                  Register src1,
-                  Register src2,
-                  Register tmp1,
-                  Register tmp2,
-                  Register tmp3) {
-  Unimplemented();
-}
-
-
-void ZBarrierSetAssembler::copy_load_at(MacroAssembler* masm,
-                  DecoratorSet decorators,
-                  BasicType type,
-                  size_t bytes,
-                  FloatRegister dst1,
-                  FloatRegister dst2,
-                  Address src,
-                  Register tmp1,
-                  Register tmp2,
-                  FloatRegister vec_tmp) {
-  Unimplemented();
-}
-
-void ZBarrierSetAssembler::copy_store_at(MacroAssembler* masm,
-                  DecoratorSet decorators,
-                  BasicType type,
-                  size_t bytes,
-                  Address dst,
-                  FloatRegister src1,
-                  FloatRegister src2,
-                  Register tmp1,
-                  Register tmp2,
-                  Register tmp3,
-                  FloatRegister vec_tmp1,
-                  FloatRegister vec_tmp2,
-                  FloatRegister vec_tmp3) {
+                                         DecoratorSet decorators,
+                                         BasicType type,
+                                         size_t bytes,
+                                         Address dst,
+                                         FloatRegister src1,
+                                         FloatRegister src2,
+                                         Register tmp1,
+                                         Register tmp2,
+                                         Register tmp3,
+                                         FloatRegister vec_tmp1,
+                                         FloatRegister vec_tmp2,
+                                         FloatRegister vec_tmp3) {
   Unimplemented();
 }
 
@@ -144,15 +634,86 @@ void ZBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm,
                                                          Register robj,
                                                          Register tmp,
                                                          Label& slowpath) {
-  Unimplemented();
+  BLOCK_COMMENT("ZBarrierSetAssembler::try_resolve_jobject_in_native {");
+
+  Label done, tagged, weak_tagged, uncolor;
+
+  // Test for tag
+  __ andi(tmp, robj, JNIHandles::tag_mask);
+  __ bnez(tmp, tagged);
+
+  // Resolve local handle
+  __ ld(robj, robj);
+  __ j(done);
+
+  __ bind(tagged);
+
+  // Test for weak tag
+  __ andi(tmp, robj, JNIHandles::TypeTag::weak_global);
+  __ bnez(tmp, weak_tagged);
+
+  // Resolve global handle
+  __ ld(robj, Address(robj, -JNIHandles::TypeTag::global));
+  __ la(tmp, load_bad_mask_from_jni_env(jni_env));
+  __ ld(tmp, tmp);
+  __ andr(tmp, robj, tmp);
+  __ bnez(tmp, slowpath);
+  __ j(uncolor);
+
+  __ bind(weak_tagged);
+
+  // Resolve weak handle
+  __ ld(robj, Address(robj, -JNIHandles::TypeTag::weak_global));
+  __ la(tmp, mark_bad_mask_from_jni_env(jni_env));
+  __ ld(tmp, tmp);
+  __ andr(tmp, robj, tmp);
+  __ bnez(tmp, slowpath);
+
+  __ bind(uncolor);
+
+  // Uncolor
+  __ srli(robj, robj, ZPointerLoadShift);
+
+  __ bind(done);
+
+  BLOCK_COMMENT("} ZBarrierSetAssembler::try_resolve_jobject_in_native");
 }
 
-void ZBarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register tmp1, Register tmp2, Label& error) {
-  Unimplemented();
+static uint16_t patch_barrier_relocation_value(int format) {
+  switch (format) {
+    case ZBarrierRelocationFormatLoadBadMask:
+      return (uint16_t)ZPointerLoadBadMask;
+    case ZBarrierRelocationFormatMarkBadMask:
+      return (uint16_t)ZPointerMarkBadMask;
+    case ZBarrierRelocationFormatStoreGoodBits:
+      return (uint16_t)ZPointerStoreGoodMask;
+    case ZBarrierRelocationFormatStoreBadMask:
+      return (uint16_t)ZPointerStoreBadMask;
+
+    default:
+      ShouldNotReachHere();
+      return 0;
+  }
 }
 
 void ZBarrierSetAssembler::patch_barrier_relocation(address addr, int format) {
-  Unimplemented();
+  const uint16_t value = patch_barrier_relocation_value(format);
+
+  int bytes;
+  switch (format) {
+    case ZBarrierRelocationFormatLoadBadMask:
+    case ZBarrierRelocationFormatMarkBadMask:
+    case ZBarrierRelocationFormatStoreGoodBits:
+    case ZBarrierRelocationFormatStoreBadMask:
+      assert(NativeInstruction::is_li16u_at(addr), "invalide zgc barrier");
+      bytes = MacroAssembler::pd_patch_instruction_size(addr, (address)(uintptr_t)value);
+      break;
+    default:
+      ShouldNotReachHere();
+  }
+
+  // A full fence is generated before icache_flush by default in invalidate_word
+  ICache::invalidate_range(addr, bytes);
 }
 
 #ifdef COMPILER2
@@ -181,7 +742,7 @@ private:
   VectorRegSet          _vp_regs;
 
 public:
-  void initialize(ZLoadBarrierStubC2* stub) {
+  void initialize(ZBarrierStubC2* stub) {
     // Record registers that needs to be saved/restored
     RegMaskIterator rmi(stub->live());
     while (rmi.has_next()) {
@@ -202,10 +763,14 @@ public:
     }
 
     // Remove C-ABI SOE registers, tmp regs and _ref register that will be updated
-    _gp_regs -= RegSet::range(x18, x27) + RegSet::of(x2) + RegSet::of(x8, x9) + RegSet::of(x5, stub->ref());
+    if (stub->result() != noreg) {
+      _gp_regs -= RegSet::range(x18, x27) + RegSet::of(x2) + RegSet::of(x8, x9) + RegSet::of(x5, stub->result());
+    } else {
+      _gp_regs -= RegSet::range(x18, x27) + RegSet::of(x2, x5) + RegSet::of(x8, x9);
+    }
   }
 
-  ZSaveLiveRegisters(MacroAssembler* masm, ZLoadBarrierStubC2* stub) :
+  ZSaveLiveRegisters(MacroAssembler* masm, ZBarrierStubC2* stub) :
       _masm(masm),
       _gp_regs(),
       _fp_regs(),
@@ -284,12 +849,61 @@ public:
 #define __ masm->
 
 void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, ZLoadBarrierStubC2* stub) const {
-  Unimplemented();
+  BLOCK_COMMENT("ZLoadBarrierStubC2");
+
+  // Stub entry
+  if (!Compile::current()->output()->in_scratch_emit_size()) {
+    __ bind(*stub->entry());
+  }
+
+  {
+    ZSaveLiveRegisters save_live_registers(masm, stub);
+    ZSetupArguments setup_arguments(masm, stub);
+    __ mv(t0, stub->slow_path());
+    __ jalr(t0);
+  }
+
+  // Stub exit
+  __ j(*stub->continuation());
 }
 
-void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm,
-                                    ZStoreBarrierStubC2* stub) const {
-  Unimplemented();
+void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm, ZStoreBarrierStubC2* stub) const {
+  BLOCK_COMMENT("ZStoreBarrierStubC2");
+
+  // Stub entry
+  __ bind(*stub->entry());
+
+  Label slow;
+  Label slow_continuation;
+  store_barrier_medium(masm,
+                       stub->ref_addr(),
+                       stub->new_zpointer(),
+                       t1,
+                       t0,
+                       stub->is_native(),
+                       stub->is_atomic(),
+                       *stub->continuation(),
+                       slow,
+                       slow_continuation);
+
+  __ bind(slow);
+
+  {
+    ZSaveLiveRegisters save_live_registers(masm, stub);
+    __ la(c_rarg0, stub->ref_addr());
+
+    if (stub->is_native()) {
+      __ la(t0, RuntimeAddress(ZBarrierSetRuntime::store_barrier_on_native_oop_field_without_healing_addr()));
+    } else if (stub->is_atomic()) {
+      __ la(t0, RuntimeAddress(ZBarrierSetRuntime::store_barrier_on_oop_field_with_healing_addr()));
+    } else {
+      __ la(t0, RuntimeAddress(ZBarrierSetRuntime::store_barrier_on_oop_field_without_healing_addr()));
+    }
+    __ jalr(t0);
+  }
+
+  // Stub exit
+  __ j(slow_continuation);
 }
 
 #undef __
@@ -300,30 +914,104 @@ void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm,
 #undef __
 #define __ ce->masm()->
 
+static void z_color(LIR_Assembler* ce, LIR_Opr ref) {
+  __ relocate(barrier_Relocation::spec(), [&] {
+    __ li16u(t1, barrier_Relocation::unpatched);
+  }, ZBarrierRelocationFormatStoreGoodBits);
+  __ slli(ref->as_register(), ref->as_register(), ZPointerLoadShift);
+  __ orr(ref->as_register(), ref->as_register(), t1);
+}
+
+static void z_uncolor(LIR_Assembler* ce, LIR_Opr ref) {
+  __ srli(ref->as_register(), ref->as_register(), ZPointerLoadShift);
+}
+
+static void check_color(LIR_Assembler* ce, LIR_Opr ref, bool on_non_strong) {
+  assert_different_registers(t0, xthread, ref->as_register());
+  int format = on_non_strong ? ZBarrierRelocationFormatMarkBadMask
+                             : ZBarrierRelocationFormatLoadBadMask;
+  Label good;
+  __ relocate(barrier_Relocation::spec(), [&] {
+    __ li16u(t0, barrier_Relocation::unpatched);
+  }, format);
+  __ andr(t0, ref->as_register(), t0);
+}
 
 void ZBarrierSetAssembler::generate_c1_color(LIR_Assembler* ce, LIR_Opr ref) const {
-  Unimplemented();
+  z_color(ce, ref);
 }
 
 void ZBarrierSetAssembler::generate_c1_uncolor(LIR_Assembler* ce, LIR_Opr ref) const {
-  Unimplemented();
-}
-
-void ZBarrierSetAssembler::generate_c1_load_barrier_test(LIR_Assembler* ce,
-                                                         LIR_Opr ref) const {
-  Unimplemented();
+  z_uncolor(ce, ref);
 }
 
 void ZBarrierSetAssembler::generate_c1_load_barrier(LIR_Assembler* ce,
                                                     LIR_Opr ref,
                                                     ZLoadBarrierStubC1* stub,
                                                     bool on_non_strong) const {
-  Unimplemented();
+  Label good;
+  check_color(ce, ref, on_non_strong);
+  __ beqz(t0, good);
+  __ j(*stub->entry());
+
+  __ bind(good);
+  z_uncolor(ce, ref);
+  __ bind(*stub->continuation());
 }
 
 void ZBarrierSetAssembler::generate_c1_load_barrier_stub(LIR_Assembler* ce,
                                                          ZLoadBarrierStubC1* stub) const {
-  Unimplemented();
+  // Stub entry
+  __ bind(*stub->entry());
+
+  Register ref = stub->ref()->as_register();
+  Register ref_addr = noreg;
+  Register tmp = noreg;
+
+  if (stub->tmp()->is_valid()) {
+    // Load address into tmp register
+    ce->leal(stub->ref_addr(), stub->tmp());
+    ref_addr = tmp = stub->tmp()->as_pointer_register();
+  } else {
+    // Address already in register
+    ref_addr = stub->ref_addr()->as_address_ptr()->base()->as_pointer_register();
+  }
+
+   assert_different_registers(ref, ref_addr, noreg);
+
+   // Save x10 unless it is the result or tmp register
+   // Set up SP to accommdate parameters and maybe x10.
+   if (ref != x10 && tmp != x10) {
+     __ sub(sp, sp, 32);
+     __ sd(x10, Address(sp, 16));
+   } else {
+     __ sub(sp, sp, 16);
+   }
+
+   // Setup arguments and call runtime stub
+   ce->store_parameter(ref_addr, 1);
+   ce->store_parameter(ref, 0);
+
+   __ far_call(stub->runtime_stub());
+
+   // Verify result
+   __ verify_oop(x10);
+
+   // Move result into place
+   if (ref != x10) {
+     __ mv(ref, x10);
+   }
+
+   // Restore x10 unless it is the result or tmp register
+   if (ref != x10 && tmp != x10) {
+     __ ld(x10, Address(sp, 16));
+     __ addi(sp, sp, 32);
+   } else {
+     __ addi(sp, sp, 16);
+   }
+
+   // Stub exit
+   __ j(*stub->continuation());
 }
 
 #undef __
@@ -331,7 +1019,39 @@ void ZBarrierSetAssembler::generate_c1_load_barrier_stub(LIR_Assembler* ce,
 
 void ZBarrierSetAssembler::generate_c1_load_barrier_runtime_stub(StubAssembler* sasm,
                                                                  DecoratorSet decorators) const {
-  Unimplemented();
+  __ prologue("zgc_load_barrier stub", false);
+
+  __ push_call_clobbered_registers_except(RegSet::of(x10));
+
+  // Setup arguments
+  __ load_parameter(0, c_rarg0);
+  __ load_parameter(1, c_rarg1);
+
+  __ call_VM_leaf(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_addr(decorators), 2);
+
+  __ pop_call_clobbered_registers_except(RegSet::of(x10));
+
+  __ epilogue();
+}
+
+void ZBarrierSetAssembler::generate_c1_store_barrier_runtime_stub(StubAssembler* sasm,
+                                                                  bool self_healing) const {
+  __ prologue("zgc_store_barrier stub", false);
+
+  __ push_call_clobbered_registers();
+
+  // Setup arguments
+  __ load_parameter(0, c_rarg0);
+
+  if (self_healing) {
+    __ call_VM_leaf(ZBarrierSetRuntime::store_barrier_on_oop_field_with_healing_addr(), 1);
+  } else {
+    __ call_VM_leaf(ZBarrierSetRuntime::store_barrier_on_oop_field_without_healing_addr(), 1);
+  }
+
+  __ pop_call_clobbered_registers();
+
+  __ epilogue();
 }
 
 #undef __
@@ -342,21 +1062,52 @@ void ZBarrierSetAssembler::generate_c1_store_barrier(LIR_Assembler* ce,
                                                      LIR_Opr new_zaddress,
                                                      LIR_Opr new_zpointer,
                                                      ZStoreBarrierStubC1* stub) const {
-  Unimplemented();
+  Register rnew_zaddress = new_zaddress->as_register();
+  Register rnew_zpointer = new_zpointer->as_register();
+
+  store_barrier_fast(ce->masm(),
+                     ce->as_Address(addr),
+                     rnew_zaddress,
+                     rnew_zpointer,
+                     t1,
+                     true,
+                     stub->is_atomic(),
+                     *stub->entry(),
+                     *stub->continuation());
 }
 
 void ZBarrierSetAssembler::generate_c1_store_barrier_stub(LIR_Assembler* ce,
                                                           ZStoreBarrierStubC1* stub) const {
-  Unimplemented();
+  // Stub entry
+  __ bind(*stub->entry());
+  Label slow;
+  Label slow_continuation;
+  store_barrier_medium(ce->masm(),
+                       ce->as_Address(stub->ref_addr()->as_address_ptr()),
+                       t1,
+                       stub->new_zpointer()->as_register(),
+                       stub->tmp()->as_pointer_register(),
+                       false /* is_native */,
+                       stub->is_atomic(),
+                       *stub->continuation(),
+                       slow,
+                       slow_continuation);
+
+  __ bind(slow);
+
+  __ la(stub->new_zpointer()->as_register(), ce->as_Address(stub->ref_addr()->as_address_ptr()));
+
+  __ sub(sp, sp, 16);
+  //Setup arguments and call runtime stub
+  assert(stub->new_zpointer()->is_valid(), "invariant");
+  ce->store_parameter(stub->new_zpointer()->as_register(), 0);
+  __ far_call(stub->runtime_stub());
+  __ addi(sp, sp, 16);
+
+  // Stub exit
+  __ j(slow_continuation);
 }
 
 #undef __
-#define __ sasm->
 
-void ZBarrierSetAssembler::generate_c1_store_barrier_runtime_stub(StubAssembler* sasm,
-                                                                  bool self_healing) const {
-  Unimplemented();
-}
-
-#undef __
 #endif // COMPILER1

--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,11 @@ class MachNode;
 class Node;
 #endif // COMPILER2
 
+const int ZBarrierRelocationFormatLoadBadMask   = 0;
+const int ZBarrierRelocationFormatMarkBadMask   = 1;
+const int ZBarrierRelocationFormatStoreGoodBits = 2;
+const int ZBarrierRelocationFormatStoreBadMask  = 3;
+
 class ZBarrierSetAssembler : public ZBarrierSetAssemblerBase {
 public:
   virtual void load_at(MacroAssembler* masm,
@@ -59,6 +64,27 @@ public:
                        Address src,
                        Register tmp1,
                        Register tmp2);
+
+  void store_barrier_fast(MacroAssembler* masm,
+                          Address ref_addr,
+                          Register rnew_zaddress,
+                          Register rnew_zpointer,
+                          Register rtmp,
+                          bool in_nmethod,
+                          bool is_atomic,
+                          Label& medium_path,
+                          Label& medium_path_continuation) const;
+
+  void store_barrier_medium(MacroAssembler* masm,
+                            Address ref_addr,
+                            Register rtmp1,
+                            Register rtmp2,
+                            Register rtmp3,
+                            bool is_native,
+                            bool is_atomic,
+                            Label& medium_path_continuation,
+                            Label& slow_path,
+                            Label& slow_path_continuation) const;
 
   virtual void store_at(MacroAssembler* masm,
                         DecoratorSet decorators,
@@ -81,8 +107,7 @@ public:
                             DecoratorSet decorators,
                             BasicType type,
                             size_t bytes,
-                            Register dst1,
-                            Register dst2,
+                            Register dst,
                             Address src,
                             Register tmp);
 
@@ -91,8 +116,7 @@ public:
                              BasicType type,
                              size_t bytes,
                              Address dst,
-                             Register src1,
-                             Register src2,
+                             Register src,
                              Register tmp1,
                              Register tmp2,
                              Register tmp3);

--- a/src/hotspot/cpu/riscv/gc/z/zGlobals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/z/zGlobals_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,11 @@
  *
  */
 
-#ifndef CPU_AARCH64_GC_Z_ZGLOBALS_AARCH64_HPP
-#define CPU_AARCH64_GC_Z_ZGLOBALS_AARCH64_HPP
+#ifndef CPU_RISCV_GC_Z_ZGLOBALS_RISCV_HPP
+#define CPU_RISCV_GC_Z_ZGLOBALS_RISCV_HPP
 
 #include "utilities/globalDefinitions.hpp"
 
 const size_t ZPlatformCacheLineSize    = 64;
 
-#endif // CPU_AARCH64_GC_Z_ZGLOBALS_AARCH64_HPP
+#endif // CPU_RISCV_GC_Z_ZGLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/gc/z/z_riscv64.ad
+++ b/src/hotspot/cpu/riscv/gc/z/z_riscv64.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+// Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,69 @@ source_hpp %{
 %}
 
 source %{
+#include "gc/z/zBarrierSetAssembler.hpp"
+
+static void z_color(MacroAssembler& _masm, const MachNode* node, Register dst, Register src, Register tmp) {
+  assert_different_registers(dst, tmp);
+
+  __ relocate(barrier_Relocation::spec(), [&] {
+    __ li16u(tmp, barrier_Relocation::unpatched);
+  }, ZBarrierRelocationFormatStoreGoodBits);
+  __ slli(dst, src, ZPointerLoadShift);
+  __ orr(dst, dst, tmp);
+}
+
+static void z_uncolor(MacroAssembler& _masm, const MachNode* node, Register ref) {
+  __ srli(ref, ref, ZPointerLoadShift);
+}
+
+static void check_color(MacroAssembler& _masm, Register ref, bool on_non_strong, Register result) {
+  int format = on_non_strong ? ZBarrierRelocationFormatMarkBadMask
+                             : ZBarrierRelocationFormatLoadBadMask;
+  __ relocate(barrier_Relocation::spec(), [&] {
+    __ li16u(result, barrier_Relocation::unpatched);
+  }, format);
+  __ andr(result, ref, result);
+}
+
+static void z_load_barrier(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register ref, Register tmp) {
+  const bool on_non_strong =
+      ((node->barrier_data() & ZBarrierWeak) != 0) ||
+      ((node->barrier_data() & ZBarrierPhantom) != 0);
+
+  if (node->barrier_data() == ZBarrierElided) {
+    z_uncolor(_masm, node, ref);
+    return;
+  }
+
+  ZLoadBarrierStubC2* const stub = ZLoadBarrierStubC2::create(node, ref_addr, ref);
+  Label good;
+  check_color(_masm, ref, on_non_strong, tmp);
+  __ beqz(tmp, good);
+  __ j(*stub->entry());
+
+  __ bind(good);
+  z_uncolor(_masm, node, ref);
+  __ bind(*stub->continuation());
+}
+
+static void z_store_barrier(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register rnew_zaddress, Register rnew_zpointer, Register tmp, bool is_atomic) {
+  if (node->barrier_data() == ZBarrierElided) {
+    z_color(_masm, node, rnew_zpointer, rnew_zaddress, t0);
+  } else {
+    bool is_native = (node->barrier_data() & ZBarrierNative) != 0;
+    ZStoreBarrierStubC2* const stub = ZStoreBarrierStubC2::create(node, ref_addr, rnew_zaddress, rnew_zpointer, is_native, is_atomic);
+    ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
+    bs_asm->store_barrier_fast(&_masm, ref_addr, rnew_zaddress, rnew_zpointer, tmp, true /* in_nmethod */, is_atomic, *stub->entry(), *stub->continuation());
+  }
+}
 %}
 
 // Load Pointer
 instruct zLoadP(iRegPNoSp dst, memory mem)
 %{
   match(Set dst (LoadP mem));
-  predicate(UseZGC && /* !needs_acquiring_load(n) && */ n->as_Load()->barrier_data() != 0);
+  predicate(UseZGC && n->as_Load()->barrier_data() != 0);
   effect(TEMP dst);
 
   ins_cost(4 * DEFAULT_COST);
@@ -45,65 +101,36 @@ instruct zLoadP(iRegPNoSp dst, memory mem)
   format %{ "ld  $dst, $mem, #@zLoadP" %}
 
   ins_encode %{
-    Unimplemented();
+    const Address ref_addr(as_Register($mem$$base), $mem$$disp);
+    __ ld($dst$$Register, ref_addr);
+    z_load_barrier(_masm, this, ref_addr, $dst$$Register, t0);
   %}
 
   ins_pipe(iload_reg_mem);
 %}
 
-// Load Pointer Volatile
-instruct zLoadPVolatile(iRegPNoSp dst, indirect mem /* sync_memory */, rFlagsReg cr)
-%{
-  match(Set dst (LoadP mem));
-  predicate(UseZGC && /* needs_acquiring_load(n) && */ n->as_Load()->barrier_data() != 0);
-  effect(TEMP dst, KILL cr);
-
-  ins_cost(VOLATILE_REF_COST);
-
-  format %{ "ldar  $dst, $mem\t" %}
-
-  ins_encode %{
-    Unimplemented();
-  %}
-
-  ins_pipe(pipe_serial);
-%}
-
 // Store Pointer
 instruct zStoreP(memory mem, iRegP src, iRegPNoSp tmp, rFlagsReg cr)
 %{
-  predicate(UseZGC && /* !needs_releasing_store(n) && */ n->as_Store()->barrier_data() != 0);
+  predicate(UseZGC && n->as_Store()->barrier_data() != 0);
   match(Set mem (StoreP mem src));
   effect(TEMP tmp, KILL cr);
 
   ins_cost(125); // XXX
-  format %{ "movq    $mem, $src\t# ptr" %}
+  format %{ "sd    $mem, $src\t# ptr" %}
   ins_encode %{
-    Unimplemented();
+    const Address ref_addr(as_Register($mem$$base), $mem$$disp);
+    z_store_barrier(_masm, this, ref_addr, $src$$Register, $tmp$$Register, t1, false /* is_atomic */);
+    __ sd($tmp$$Register, ref_addr);
   %}
   ins_pipe(pipe_serial);
 %}
 
-// Store Pointer Volatile
-instruct zStorePVolatile(indirect mem, iRegP src, iRegPNoSp tmp, rFlagsReg cr)
-%{
-  predicate(UseZGC && /* needs_releasing_store(n) && */ n->as_Store()->barrier_data() != 0);
-  match(Set mem (StoreP mem src));
-  effect(TEMP tmp, KILL cr);
-
-  ins_cost(125); // XXX
-  format %{ "movq    $mem, $src\t# ptr" %}
-  ins_encode %{
-    Unimplemented();
-  %}
-  ins_pipe(pipe_serial);
-%}
-
-instruct zCompareAndSwapP(iRegINoSp res, indirect mem, iRegP oldval, iRegP newval, rFlagsReg cr) %{
+instruct zCompareAndSwapP(iRegINoSp res, indirect mem, iRegP oldval, iRegP newval, iRegPNoSp oldval_tmp, iRegPNoSp newval_tmp, rFlagsReg cr) %{
   match(Set res (CompareAndSwapP mem (Binary oldval newval)));
   match(Set res (WeakCompareAndSwapP mem (Binary oldval newval)));
-  predicate(UseZGC && /* !needs_acquiring_load_exclusive(n) && */ n->as_LoadStore()->barrier_data() != 0);
-  effect(KILL cr, TEMP_DEF res);
+  predicate(UseZGC && !needs_acquiring_load_reserved(n) && n->as_LoadStore()->barrier_data() != 0);
+  effect(TEMP oldval_tmp, TEMP newval_tmp, KILL cr, TEMP_DEF res);
 
   ins_cost(2 * VOLATILE_REF_COST);
 
@@ -111,17 +138,21 @@ instruct zCompareAndSwapP(iRegINoSp res, indirect mem, iRegP oldval, iRegP newva
             "mv $res, $res == $oldval" %}
 
   ins_encode %{
-    Unimplemented();
+    guarantee($mem$$disp == 0, "impossible encoding");
+    Address ref_addr($mem$$Register);
+    z_color(_masm, this, $oldval_tmp$$Register, $oldval$$Register, t0);
+    z_store_barrier(_masm, this, ref_addr, $newval$$Register, $newval_tmp$$Register, t1, true /* is_atomic */);
+    __ cmpxchg($mem$$Register, $oldval_tmp$$Register, $newval_tmp$$Register, Assembler::int64, Assembler::relaxed /* acquire */, Assembler::rl /* release */, $res$$Register, true /* result_as_bool */);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct zCompareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP newval, rFlagsReg cr) %{
+instruct zCompareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP newval, iRegPNoSp oldval_tmp, iRegPNoSp newval_tmp, rFlagsReg cr) %{
   match(Set res (CompareAndSwapP mem (Binary oldval newval)));
   match(Set res (WeakCompareAndSwapP mem (Binary oldval newval)));
-  predicate(UseZGC && /* needs_acquiring_load_exclusive(n) && */ n->as_LoadStore()->barrier_data() != 0);
-  effect(KILL cr, TEMP_DEF res);
+  predicate(UseZGC && needs_acquiring_load_reserved(n) && n->as_LoadStore()->barrier_data() != 0);
+  effect(TEMP oldval_tmp, TEMP newval_tmp, KILL cr, TEMP_DEF res);
 
   ins_cost(2 * VOLATILE_REF_COST);
 
@@ -129,39 +160,53 @@ instruct zCompareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP ne
             "mv $res, $res == $oldval" %}
 
   ins_encode %{
-    Unimplemented();
+    guarantee($mem$$disp == 0, "impossible encoding");
+    Address ref_addr($mem$$Register);
+    z_color(_masm, this, $oldval_tmp$$Register, $oldval$$Register, t0);
+    z_store_barrier(_masm, this, ref_addr, $newval$$Register, $newval_tmp$$Register, t1, true /* is_atomic */);
+    __ cmpxchg($mem$$Register, $oldval_tmp$$Register, $newval_tmp$$Register, Assembler::int64, Assembler::aq /* acquire */, Assembler::rl /* release */, $res$$Register, true /* result_as_bool */);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct zCompareAndExchangeP(iRegPNoSp res, indirect mem, iRegP oldval, iRegP newval) %{
+instruct zCompareAndExchangeP(iRegPNoSp res, indirect mem, iRegP oldval, iRegP newval, iRegPNoSp oldval_tmp, iRegPNoSp newval_tmp, rFlagsReg cr) %{
   match(Set res (CompareAndExchangeP mem (Binary oldval newval)));
-  predicate(UseZGC && /* !needs_acquiring_load_exclusive(n) && */ n->as_LoadStore()->barrier_data() != 0);
-  effect(TEMP_DEF res);
+  predicate(UseZGC && !needs_acquiring_load_reserved(n) && n->as_LoadStore()->barrier_data() != 0);
+  effect(TEMP oldval_tmp, TEMP newval_tmp, KILL cr, TEMP_DEF res);
 
   ins_cost(2 * VOLATILE_REF_COST);
 
   format %{ "cmpxchg $res = $mem, $oldval, $newval, #@zCompareAndExchangeP" %}
 
   ins_encode %{
-    Unimplemented();
+    guarantee($mem$$disp == 0, "impossible encoding");
+    Address ref_addr($mem$$Register);
+    z_color(_masm, this, $oldval_tmp$$Register, $oldval$$Register, t0);
+    z_store_barrier(_masm, this, ref_addr, $newval$$Register, $newval_tmp$$Register, t1, true /* is_atomic */);
+    __ cmpxchg($mem$$Register, $oldval_tmp$$Register, $newval_tmp$$Register, Assembler::int64, Assembler::relaxed /* acquire */, Assembler::rl /* release */, $res$$Register);
+    z_uncolor(_masm, this, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct zCompareAndExchangePAcq(iRegPNoSp res, indirect mem, iRegP oldval, iRegP newval) %{
+instruct zCompareAndExchangePAcq(iRegPNoSp res, indirect mem, iRegP oldval, iRegP newval, iRegPNoSp oldval_tmp, iRegPNoSp newval_tmp, rFlagsReg cr) %{
   match(Set res (CompareAndExchangeP mem (Binary oldval newval)));
-  predicate(UseZGC && /* needs_acquiring_load_exclusive(n) && */ n->as_LoadStore()->barrier_data() != 0);
-  effect(TEMP_DEF res);
+  predicate(UseZGC && needs_acquiring_load_reserved(n) && n->as_LoadStore()->barrier_data() != 0);
+  effect(TEMP oldval_tmp, TEMP newval_tmp, KILL cr, TEMP_DEF res);
 
   ins_cost(2 * VOLATILE_REF_COST);
 
   format %{ "cmpxchg $res = $mem, $oldval, $newval, #@zCompareAndExchangePAcq" %}
 
   ins_encode %{
-    Unimplemented();
+    guarantee($mem$$disp == 0, "impossible encoding");
+    Address ref_addr($mem$$Register);
+    z_color(_masm, this, $oldval_tmp$$Register, $oldval$$Register, t0);
+    z_store_barrier(_masm, this, ref_addr, $newval$$Register, $newval_tmp$$Register, t1, true /* is_atomic */);
+    __ cmpxchg($mem$$Register, $oldval_tmp$$Register, $newval_tmp$$Register, Assembler::int64, Assembler::aq /* acquire */, Assembler::rl /* release */, $res$$Register);
+    z_uncolor(_masm, this, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
@@ -169,7 +214,7 @@ instruct zCompareAndExchangePAcq(iRegPNoSp res, indirect mem, iRegP oldval, iReg
 
 instruct zGetAndSetP(indirect mem, iRegP newv, iRegPNoSp prev, rFlagsReg cr) %{
   match(Set prev (GetAndSetP mem newv));
-  predicate(UseZGC && /* !needs_acquiring_load_exclusive(n) && */ n->as_LoadStore()->barrier_data() != 0);
+  predicate(UseZGC && !needs_acquiring_load_reserved(n) && n->as_LoadStore()->barrier_data() != 0);
   effect(TEMP_DEF prev, KILL cr);
 
   ins_cost(2 * VOLATILE_REF_COST);
@@ -177,7 +222,9 @@ instruct zGetAndSetP(indirect mem, iRegP newv, iRegPNoSp prev, rFlagsReg cr) %{
   format %{ "atomic_xchg  $prev, $newv, [$mem], #@zGetAndSetP" %}
 
   ins_encode %{
-    Unimplemented();
+    z_store_barrier(_masm, this, Address($mem$$Register), $newv$$Register, $prev$$Register, t1, true /* is_atomic */);
+    __ atomic_xchg($prev$$Register, $prev$$Register, $mem$$Register);
+    z_uncolor(_masm, this, $prev$$Register);
   %}
 
   ins_pipe(pipe_serial);
@@ -185,15 +232,17 @@ instruct zGetAndSetP(indirect mem, iRegP newv, iRegPNoSp prev, rFlagsReg cr) %{
 
 instruct zGetAndSetPAcq(indirect mem, iRegP newv, iRegPNoSp prev, rFlagsReg cr) %{
   match(Set prev (GetAndSetP mem newv));
-  predicate(UseZGC && /* needs_acquiring_load_exclusive(n) && */ n->as_LoadStore()->barrier_data() != 0);
+  predicate(UseZGC && needs_acquiring_load_reserved(n) && n->as_LoadStore()->barrier_data() != 0);
   effect(TEMP_DEF prev, KILL cr);
 
-  ins_cost(VOLATILE_REF_COST);
+  ins_cost(2 * VOLATILE_REF_COST);
 
   format %{ "atomic_xchg_acq  $prev, $newv, [$mem], #@zGetAndSetPAcq" %}
 
   ins_encode %{
-    Unimplemented();
+    z_store_barrier(_masm, this, Address($mem$$Register), $newv$$Register, $prev$$Register, t1, true /* is_atomic */);
+    __ atomic_xchgal($prev$$Register, $prev$$Register, $mem$$Register);
+    z_uncolor(_masm, this, $prev$$Register);
   %}
   ins_pipe(pipe_serial);
 %}

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -561,8 +561,8 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
 
   beqz(value, done);           // Use NULL as-is.
   // Test for tag.
-  andi(t0, value, JNIHandles::tag_mask);
-  bnez(t0, tagged);
+  andi(tmp1, value, JNIHandles::tag_mask);
+  bnez(tmp1, tagged);
 
   // Resolve local handle
   access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, value, Address(value, 0), tmp1, tmp2);
@@ -570,13 +570,14 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
   j(done);
 
   bind(tagged);
-  // Test for jweak tag.
-  andi(t0, value, JNIHandles::TypeTag::weak_global);
-  bnez(t0, weak_tagged);
+  STATIC_ASSERT(JNIHandles::TypeTag::weak_global == 0b1);
+  andi(tmp1, value, JNIHandles::TypeTag::weak_global);
+  bnez(tmp1, weak_tagged);
 
   // Resolve global handle
   access_load_at(T_OBJECT, IN_NATIVE, value,
                  Address(value, -JNIHandles::TypeTag::global), tmp1, tmp2);
+  verify_oop(value);
   j(done);
 
   bind(weak_tagged);
@@ -596,9 +597,10 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
 
 #ifdef ASSERT
   {
+    STATIC_ASSERT(JNIHandles::TypeTag::global == 0b10);
     Label valid_global_tag;
-    andi(t0, value, JNIHandles::TypeTag::global); // Test for global tag.
-    bnez(t0, valid_global_tag);
+    andi(tmp1, value, JNIHandles::TypeTag::global); // Test for global tag.
+    bnez(tmp1, valid_global_tag);
     stop("non global jobject using resolve_global_jobject");
     bind(valid_global_tag);
   }
@@ -777,6 +779,11 @@ void MacroAssembler::la(Register Rd, const Address &adr) {
 void MacroAssembler::la(Register Rd, Label &label) {
   IncompressibleRegion ir(this);   // the label address may be patched back.
   wrap_label(Rd, label, &MacroAssembler::la);
+}
+
+void MacroAssembler::li16u(Register Rd, int32_t imm) {
+  lui(Rd, imm << 12);
+  srli(Rd, Rd, 12);
 }
 
 void MacroAssembler::li32(Register Rd, int32_t imm) {
@@ -1426,6 +1433,11 @@ static int patch_imm_in_li64(address branch, address target) {
   return LI64_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
 }
 
+static int patch_imm_in_li16u(address branch, int32_t target) {
+  Assembler::patch(branch, 31, 12, target & 0xfffff); // patch lui only
+  return NativeInstruction::instruction_size;
+}
+
 int MacroAssembler::patch_imm_in_li32(address branch, int32_t target) {
   const int LI32_INSTRUCTIONS_NUM = 2;                                          // lui + addiw
   int64_t upper = (intptr_t)target;
@@ -1515,6 +1527,9 @@ int MacroAssembler::pd_patch_instruction_size(address branch, address target) {
   } else if (NativeInstruction::is_li32_at(branch)) {                 // li32
     int64_t imm = (intptr_t)target;
     return patch_imm_in_li32(branch, (int32_t)imm);
+  } else if (NativeInstruction::is_li16u_at(branch)) {
+    int64_t imm = (intptr_t)target;
+    return patch_imm_in_li16u(branch, (int32_t)imm);
   } else {
 #ifdef ASSERT
     tty->print_cr("pd_patch_instruction_size: instruction 0x%x at " INTPTR_FORMAT " could not be patched!\n",
@@ -2447,6 +2462,10 @@ void MacroAssembler::safepoint_poll(Label& slow_path, bool at_return, bool acqui
 
 void MacroAssembler::cmpxchgptr(Register oldv, Register newv, Register addr, Register tmp,
                                 Label &succeed, Label *fail) {
+  assert_different_registers(addr, tmp);
+  assert_different_registers(newv, tmp);
+  assert_different_registers(oldv, tmp);
+
   // oldv holds comparison value
   // newv holds value to write in exchange
   // addr identifies memory word to compare against/update
@@ -2633,6 +2652,9 @@ void MacroAssembler::cmpxchg(Register addr, Register expected,
                              Assembler::Aqrl acquire, Assembler::Aqrl release,
                              Register result, bool result_as_bool) {
   assert(size != int8 && size != int16, "unsupported operand size");
+  assert_different_registers(addr, t0);
+  assert_different_registers(expected, t0);
+  assert_different_registers(new_val, t0);
 
   Label retry_load, done, ne_done;
   bind(retry_load);
@@ -2665,6 +2687,10 @@ void MacroAssembler::cmpxchg_weak(Register addr, Register expected,
                                   enum operand_size size,
                                   Assembler::Aqrl acquire, Assembler::Aqrl release,
                                   Register result) {
+  assert_different_registers(addr, t0);
+  assert_different_registers(expected, t0);
+  assert_different_registers(new_val, t0);
+
   Label fail, done;
   load_reserved(addr, size, acquire);
   bne(t0, expected, fail);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -675,6 +675,7 @@ public:
   void la(Register Rd, const address dest);
   void la(Register Rd, const Address &adr);
 
+  void li16u(Register Rd, int32_t imm);
   void li32(Register Rd, int32_t imm);
   void li64(Register Rd, int64_t imm);
   void li(Register Rd, int64_t imm);  // optimized load immediate

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,6 +95,12 @@ bool NativeInstruction::is_movptr_at(address instr) {
           is_jalr_at(instr + instruction_size * 5) ||
           is_load_at(instr + instruction_size * 5)) && // Addi/Jalr/Load
          check_movptr_data_dependency(instr);
+}
+
+bool NativeInstruction::is_li16u_at(address instr) {
+  return is_lui_at(instr) && // lui
+         is_srli_at(instr + instruction_size) && // srli
+         check_li16u_data_dependency(instr);
 }
 
 bool NativeInstruction::is_li32_at(address instr) {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2018, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,14 @@ class NativeInstruction {
   static bool is_addiw_to_zr_at(address instr) { assert_cond(instr != NULL); return is_addiw_at(instr) && extract_rd(instr) == zr; }
   static bool is_lui_at(address instr)        { assert_cond(instr != NULL); return extract_opcode(instr) == 0b0110111; }
   static bool is_lui_to_zr_at(address instr)  { assert_cond(instr != NULL); return is_lui_at(instr) && extract_rd(instr) == zr; }
+
+  static bool is_srli_at(address instr) {
+    assert_cond(instr != NULL);
+    return extract_opcode(instr) == 0b0010011 &&
+           extract_funct3(instr) == 0b101 &&
+           Assembler::extract(((unsigned*)instr)[0], 31, 26) == 0b000000;
+  }
+
   static bool is_slli_shift_at(address instr, uint32_t shift) {
     assert_cond(instr != NULL);
     return (extract_opcode(instr) == 0b0010011 && // opcode field
@@ -153,6 +161,17 @@ class NativeInstruction {
            extract_rs1(addi4) == extract_rd(addi4);
   }
 
+  // the instruction sequence of li16u is as below:
+  //     lui
+  //     srli
+  static bool check_li16u_data_dependency(address instr) {
+    address lui = instr;
+    address srli = lui + instruction_size;
+
+    return extract_rs1(srli) == extract_rd(lui) &&
+           extract_rs1(srli) == extract_rd(srli);
+  }
+
   // the instruction sequence of li32 is as below:
   //     lui
   //     addiw
@@ -186,6 +205,7 @@ class NativeInstruction {
   }
 
   static bool is_movptr_at(address instr);
+  static bool is_li16u_at(address instr);
   static bool is_li32_at(address instr);
   static bool is_li64_at(address instr);
   static bool is_pc_relative_at(address branch);

--- a/src/hotspot/cpu/riscv/relocInfo_riscv.hpp
+++ b/src/hotspot/cpu/riscv/relocInfo_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,8 @@
     // Relocations are byte-aligned.
     offset_unit        =  1,
     // Must be at least 1 for RelocInfo::narrow_oop_in_const.
-    format_width       =  1
+    // Must be at least 2 for ZGC GC barrier patching.
+    format_width       =  2
   };
 
  public:

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -960,7 +960,7 @@ class StubGenerator: public StubCodeGenerator {
     Label same_aligned;
     Label copy_big, copy32_loop, copy8_loop, copy_small, done;
 
-    __ beqz(count, done);
+    __ beqz(count, done, true);
     __ slli(cnt, count, exact_log2(granularity));
     if (is_backwards) {
       __ add(src, s, cnt);
@@ -974,15 +974,15 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(tmp, cnt, -32);
       __ bgez(tmp, copy32_loop);
       __ addi(tmp, cnt, -8);
-      __ bgez(tmp, copy8_loop);
+      __ bgez(tmp, copy8_loop, true);
       __ j(copy_small);
     } else {
       __ mv(tmp, 16);
-      __ blt(cnt, tmp, copy_small);
+      __ blt(cnt, tmp, copy_small, true);
 
       __ xorr(tmp, src, dst);
       __ andi(tmp, tmp, 0b111);
-      __ bnez(tmp, copy_small);
+      __ bnez(tmp, copy_small, true);
 
       __ bind(same_aligned);
       __ andi(tmp, src, 0b111);
@@ -998,12 +998,12 @@ class StubGenerator: public StubCodeGenerator {
         __ addi(dst, dst, step);
       }
       __ addi(cnt, cnt, -granularity);
-      __ beqz(cnt, done);
+      __ beqz(cnt, done, true);
       __ j(same_aligned);
 
       __ bind(copy_big);
       __ mv(tmp, 32);
-      __ blt(cnt, tmp, copy8_loop);
+      __ blt(cnt, tmp, copy8_loop, true);
     }
     __ bind(copy32_loop);
     if (is_backwards) {
@@ -1198,7 +1198,10 @@ class StubGenerator: public StubCodeGenerator {
     // use fwd copy when (d-s) above_equal (count*size)
     __ sub(t0, d, s);
     __ slli(t1, count, exact_log2(size));
-    __ bgeu(t0, t1, nooverlap_target);
+    Label L_continue;
+    __ bltu(t0, t1, L_continue);
+    __ j(nooverlap_target);
+    __ bind(L_continue);
 
     DecoratorSet decorators = IN_HEAP | IS_ARRAY;
     if (dest_uninitialized) {

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -615,23 +615,8 @@ class StubGenerator: public StubCodeGenerator {
     // make sure object is 'reasonable'
     __ beqz(x10, exit); // if obj is NULL it is OK
 
-#if INCLUDE_ZGC
-    if (UseZGC) {
-      Unimplemented();
-    }
-#endif
-
-    // Check if the oop is in the right area of memory
-    __ mv(c_rarg3, (intptr_t) Universe::verify_oop_mask());
-    __ andr(c_rarg2, x10, c_rarg3);
-    __ mv(c_rarg3, (intptr_t) Universe::verify_oop_bits());
-
-    // Compare c_rarg2 and c_rarg3.
-    __ bne(c_rarg2, c_rarg3, error);
-
-    // make sure klass is 'reasonable', which is not zero.
-    __ load_klass(x10, x10);  // get klass
-    __ beqz(x10, error);      // if klass is NULL it is broken
+    BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
+    bs_asm->check_oop(_masm, x10, c_rarg2, c_rarg3, error);
 
     // return if everything seems ok
     __ bind(exit);
@@ -957,41 +942,23 @@ class StubGenerator: public StubCodeGenerator {
     }
   }
 
-  void copy_memory(bool is_aligned, Register s, Register d,
-                   Register count, Register tmp, int step) {
+  void copy_memory(DecoratorSet decorators, BasicType type, bool is_aligned,
+                   Register s, Register d, Register count, Register tmp, int step) {
     if (UseRVV) {
-      return copy_memory_v(s, d, count, tmp, step);
+      // TODO: add gc barriers when copying oops
+      if (UseZGC && !is_reference_type(type))
+        return copy_memory_v(s, d, count, tmp, step);
     }
 
     bool is_backwards = step < 0;
     int granularity = uabs(step);
 
     const Register src = x30, dst = x31, cnt = x15, tmp3 = x16, tmp4 = x17, tmp5 = x14, tmp6 = x13;
+    const Register gct1 = x28, gct2 = x29, gct3 = t2;
+    BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
 
     Label same_aligned;
     Label copy_big, copy32_loop, copy8_loop, copy_small, done;
-
-    copy_insn ld_arr = NULL, st_arr = NULL;
-    switch (granularity) {
-      case 1 :
-        ld_arr = (copy_insn)&MacroAssembler::lbu;
-        st_arr = (copy_insn)&MacroAssembler::sb;
-        break;
-      case 2 :
-        ld_arr = (copy_insn)&MacroAssembler::lhu;
-        st_arr = (copy_insn)&MacroAssembler::sh;
-        break;
-      case 4 :
-        ld_arr = (copy_insn)&MacroAssembler::lwu;
-        st_arr = (copy_insn)&MacroAssembler::sw;
-        break;
-      case 8 :
-        ld_arr = (copy_insn)&MacroAssembler::ld;
-        st_arr = (copy_insn)&MacroAssembler::sd;
-        break;
-      default :
-        ShouldNotReachHere();
-    }
 
     __ beqz(count, done);
     __ slli(cnt, count, exact_log2(granularity));
@@ -1024,8 +991,8 @@ class StubGenerator: public StubCodeGenerator {
         __ addi(src, src, step);
         __ addi(dst, dst, step);
       }
-      (_masm->*ld_arr)(tmp3, Address(src), t0);
-      (_masm->*st_arr)(tmp3, Address(dst), t0);
+      bs_asm->copy_load_at(_masm, decorators, type, granularity, tmp3, Address(src), gct1);
+      bs_asm->copy_store_at(_masm, decorators, type, granularity, Address(dst), tmp3, gct1, gct2, gct3);
       if (!is_backwards) {
         __ addi(src, src, step);
         __ addi(dst, dst, step);
@@ -1044,14 +1011,15 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(dst, dst, -wordSize * 4);
     }
     // we first load 32 bytes, then write it, so the direction here doesn't matter
-    __ ld(tmp3, Address(src));
-    __ ld(tmp4, Address(src, 8));
-    __ ld(tmp5, Address(src, 16));
-    __ ld(tmp6, Address(src, 24));
-    __ sd(tmp3, Address(dst));
-    __ sd(tmp4, Address(dst, 8));
-    __ sd(tmp5, Address(dst, 16));
-    __ sd(tmp6, Address(dst, 24));
+    bs_asm->copy_load_at(_masm, decorators, type, 8, tmp3, Address(src), gct1);
+    bs_asm->copy_load_at(_masm, decorators, type, 8, tmp4, Address(src, 8), gct1);
+    bs_asm->copy_load_at(_masm, decorators, type, 8, tmp5, Address(src, 16), gct1);
+    bs_asm->copy_load_at(_masm, decorators, type, 8, tmp6, Address(src, 24), gct1);
+
+    bs_asm->copy_store_at(_masm, decorators, type, 8, Address(dst), tmp3, gct1, gct2, gct3);
+    bs_asm->copy_store_at(_masm, decorators, type, 8, Address(dst, 8), tmp4, gct1, gct2, gct3);
+    bs_asm->copy_store_at(_masm, decorators, type, 8, Address(dst, 16), tmp5, gct1, gct2, gct3);
+    bs_asm->copy_store_at(_masm, decorators, type, 8, Address(dst, 24), tmp6, gct1, gct2, gct3);
 
     if (!is_backwards) {
       __ addi(src, src, wordSize * 4);
@@ -1071,8 +1039,9 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(src, src, -wordSize);
       __ addi(dst, dst, -wordSize);
     }
-    __ ld(tmp3, Address(src));
-    __ sd(tmp3, Address(dst));
+    bs_asm->copy_load_at(_masm, decorators, type, 8, tmp3, Address(src), gct1);
+    bs_asm->copy_store_at(_masm, decorators, type, 8, Address(dst), tmp3, gct1, gct2, gct3);
+
     if (!is_backwards) {
       __ addi(src, src, wordSize);
       __ addi(dst, dst, wordSize);
@@ -1088,8 +1057,10 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(src, src, step);
       __ addi(dst, dst, step);
     }
-    (_masm->*ld_arr)(tmp3, Address(src), t0);
-    (_masm->*st_arr)(tmp3, Address(dst), t0);
+
+    bs_asm->copy_load_at(_masm, decorators, type, granularity, tmp3, Address(src), gct1);
+    bs_asm->copy_store_at(_masm, decorators, type, granularity, Address(dst), tmp3, gct1, gct2, gct3);
+
     if (!is_backwards) {
       __ addi(src, src, step);
       __ addi(dst, dst, step);
@@ -1176,7 +1147,7 @@ class StubGenerator: public StubCodeGenerator {
       // UnsafeCopyMemory page error: continue after ucm
       bool add_entry = !is_oop && (!aligned || sizeof(jlong) == size);
       UnsafeCopyMemoryMark ucmm(this, add_entry, true);
-      copy_memory(aligned, s, d, count, t0, size);
+      copy_memory(decorators, is_oop ? T_OBJECT : T_BYTE, aligned, s, d, count, t0, size);
     }
 
     if (is_oop) {
@@ -1249,7 +1220,7 @@ class StubGenerator: public StubCodeGenerator {
       // UnsafeCopyMemory page error: continue after ucm
       bool add_entry = !is_oop && (!aligned || sizeof(jlong) == size);
       UnsafeCopyMemoryMark ucmm(this, add_entry, true);
-      copy_memory(aligned, s, d, count, t0, -size);
+      copy_memory(decorators, is_oop ? T_OBJECT : T_BYTE, aligned, s, d, count, t0, -size);
     }
 
     if (is_oop) {
@@ -1539,6 +1510,9 @@ class StubGenerator: public StubCodeGenerator {
     const Register copied_oop  = x7;        // actual oop copied
     const Register r9_klass    = x9;        // oop._klass
 
+    // Registers used as gc temps (x15, x16, x17 are save-on-call)
+    const Register gct1 = x15, gct2 = x16, gct3 = x17;
+
     //---------------------------------------------------------------
     // Assembler stub will be used for this call to arraycopy
     // if the two arrays are subtypes of Object[] but the
@@ -1580,10 +1554,12 @@ class StubGenerator: public StubCodeGenerator {
 #endif //ASSERT
 
     DecoratorSet decorators = IN_HEAP | IS_ARRAY | ARRAYCOPY_CHECKCAST | ARRAYCOPY_DISJOINT;
-    bool is_oop = true;
     if (dest_uninitialized) {
       decorators |= IS_DEST_UNINITIALIZED;
     }
+
+    bool is_oop = true;
+    int element_size = UseCompressedOops ? 4 : 8;
 
     BarrierSetAssembler *bs = BarrierSet::barrier_set()->barrier_set_assembler();
     bs->arraycopy_prologue(_masm, decorators, is_oop, from, to, count, wb_pre_saved_regs);
@@ -1607,14 +1583,18 @@ class StubGenerator: public StubCodeGenerator {
     __ align(OptoLoopAlignment);
 
     __ BIND(L_store_element);
-    __ store_heap_oop(Address(to, 0), copied_oop, noreg, noreg, noreg, AS_RAW); // store the oop
+    bs->copy_store_at(_masm, decorators, T_OBJECT, element_size,
+                      Address(to, 0), copied_oop,
+                      gct1, gct2, gct3);
     __ add(to, to, UseCompressedOops ? 4 : 8);
     __ sub(count, count, 1);
     __ beqz(count, L_do_card_marks);
 
     // ======== loop entry is here ========
     __ BIND(L_load_element);
-    __ load_heap_oop(copied_oop, Address(from, 0), noreg, noreg, AS_RAW); // load the oop
+    bs->copy_load_at(_masm, decorators, T_OBJECT, element_size,
+                     copied_oop, Address(from, 0),
+                     gct1);
     __ add(from, from, UseCompressedOops ? 4 : 8);
     __ beqz(copied_oop, L_store_element);
 
@@ -3751,7 +3731,7 @@ class StubGenerator: public StubCodeGenerator {
       framesize // inclusive of return address
     };
 
-    const int insts_size = 512;
+    const int insts_size = 1024;
     const int locs_size  = 64;
 
     CodeBuffer code(name, insts_size, locs_size);
@@ -3990,7 +3970,7 @@ class StubGenerator: public StubCodeGenerator {
       framesize // inclusive of return address
     };
 
-    int insts_size = 512;
+    int insts_size = 1024;
     int locs_size = 64;
     CodeBuffer code("jfr_write_checkpoint", insts_size, locs_size);
     OopMapSet* oop_maps = new OopMapSet();

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ static bool returns_to_call_stub(address return_pc) {
 
 enum platform_dependent_constants {
   code_size1 = 19000,          // simply increase if too small (assembler will crash if too small)
-  code_size2 = 28000           // simply increase if too small (assembler will crash if too small)
+  code_size2 = 128000          // simply increase if too small (assembler will crash if too small)
 };
 
 class riscv {

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1132,6 +1132,12 @@ void LIR_List::set_cmp_oprs(LIR_Op* op) {
       op->as_Op4()->set_in_opr3(_cmp_opr1);
       op->as_Op4()->set_in_opr4(_cmp_opr2);
       break;
+    case lir_cas_long:
+    case lir_cas_obj:
+    case lir_cas_int:
+      _cmp_opr1 = op->as_OpCompareAndSwap()->result_opr();
+      _cmp_opr2 = LIR_OprFact::intConst(0);
+      break;
     default:
       break;
   }

--- a/src/hotspot/share/gc/z/c1/zBarrierSetC1.hpp
+++ b/src/hotspot/share/gc/z/c1/zBarrierSetC1.hpp
@@ -60,6 +60,7 @@ private:
   LIR_Opr _ref_addr;
   LIR_Opr _new_zaddress;
   LIR_Opr _new_zpointer;
+  LIR_Opr _tmp;
   bool    _is_atomic;
   address _runtime_stub;
 
@@ -67,12 +68,14 @@ public:
   ZStoreBarrierStubC1(LIRAccess& access,
                       LIR_Opr new_zaddress,
                       LIR_Opr new_zpointer,
+                      LIR_Opr tmp,
                       bool is_atomic,
                       address runtime_stub);
 
   LIR_Opr ref_addr() const;
   LIR_Opr new_zaddress() const;
   LIR_Opr new_zpointer() const;
+  LIR_Opr tmp() const;
   bool is_atomic() const;
   address runtime_stub() const;
 

--- a/src/hotspot/share/gc/z/zAddress.inline.hpp
+++ b/src/hotspot/share/gc/z/zAddress.inline.hpp
@@ -39,7 +39,7 @@
 
 inline uintptr_t untype(zoffset offset) {
   const uintptr_t value = static_cast<uintptr_t>(offset);
-  assert((value & ~ZAddressOffsetMask) == 0, "must have no other bits");
+  assert(value <= ZAddressOffsetMax, "must have no other bits");
   return value;
 }
 
@@ -50,13 +50,18 @@ inline uintptr_t untype(zoffset_end offset) {
 }
 
 inline zoffset to_zoffset(uintptr_t value) {
-  assert((value & ~ZAddressOffsetMask) == 0, "must have no other bits");
+  assert(value <= ZAddressOffsetMax, "must have no other bits");
   return zoffset(value);
 }
 
 inline zoffset to_zoffset(zoffset_end offset) {
   const uintptr_t value = untype(offset);
   return to_zoffset(value);
+}
+
+inline bool is_overflow(zoffset offset, size_t size) {
+  const uintptr_t value = untype(offset);
+  return value + size > ZAddressOffsetMax;
 }
 
 inline zoffset operator+(zoffset offset, size_t size) {

--- a/src/hotspot/share/gc/z/zPage.inline.hpp
+++ b/src/hotspot/share/gc/z/zPage.inline.hpp
@@ -466,6 +466,10 @@ inline zaddress ZPage::alloc_object(size_t size) {
 
   const size_t aligned_size = align_up(size, object_alignment());
   const zoffset addr = top();
+  if (is_overflow(addr, aligned_size)) {
+    return zaddress::null;
+  }
+
   const zoffset new_top = addr + aligned_size;
 
   if (new_top > end()) {
@@ -485,6 +489,9 @@ inline zaddress ZPage::alloc_object_atomic(size_t size) {
   zoffset addr = top();
 
   for (;;) {
+    if (is_overflow(addr, aligned_size)) {
+      return zaddress::null;
+    }
     const zoffset new_top = addr + aligned_size;
     if (new_top > end()) {
       // Not enough space left


### PR DESCRIPTION
Hi,

Please review this PR, porting zgc generational to RISC-V.

The load barrier we now have for RISC-V:
```
  lui(tmp, barrier_Relocation::unpatched << 12);  // put metadata_bits in tmp[31:12], filling in the lowest 12 bits with zeros
  srli(tmp, tmp, 12);
  andr(tmp, ref, tmp);
  beqz(tmp, good);
  j(*stub->entry());

good:
  srli(ref, ref, ZPointerLoadShift);
```

It's a little bloated, but we can simplified it by introduing bexit from the Zbs extension in the future, and it will look like:
```
  bexti(tmp, ref, barrier_Relocation::unpatched);
  beqz(tmp, good);
  j(*stub->entry());

good:
  srli(ref, ref, ZPointerLoadShift);
```

To go further with the pointer masking from RISC-V "J" extension, we can remove the uncolor instruciton by putting the color bits on the upper 16 bits of z pointers, so that we can have the hardware ignore them at all. 

copy_load_barrier and copy_store_barrier for copy_memory with the risc-v vector extension (-XX:+UseRVV) will be implemented separately.

It includes 2 patches from the jdk mainline that it depends on, one of which is the RISC-V port of loom.

Testing on Linux-riscv64 HiFive Unmatched board:
* Server release & fastdebug build OK.
* Passed tier1 tests (release build).
* Passed jtreg tests under test/hotspot/jtreg/gc/z (release build).
* Perfomed benchmark tests like SPECjvm2008, SPECjbb2015 (release build).
Testing on Linux-riscv64 Qemu:
* Passed jtreg tests under test (release build) without new failures compared to the jdk mainline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/zgc pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/zgc pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/zgc/pull/10.diff">https://git.openjdk.org/zgc/pull/10.diff</a>

</details>
