### PR TITLE
8301584: Generational ZGC: Add barrier elision tests

### DIFF
--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -30,6 +30,7 @@
 #include "opto/loopnode.hpp"
 #include "opto/matcher.hpp"
 #include "opto/memnode.hpp"
+#include "opto/machnode.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 // This means the access is mismatched. This means the value of an access
@@ -302,6 +303,12 @@ public:
   virtual void emit_stubs(CodeBuffer& cb) const { }
 
   static int arraycopy_payload_base_offset(bool is_array);
+
+#ifndef PRODUCT
+  virtual void dump_barrier_data(const MachNode* mach, outputStream* st) const {
+    st->print("%x", mach->barrier_data());
+  };
+#endif
 };
 
 #endif // SHARE_GC_SHARED_C2_BARRIERSETC2_HPP

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -28,9 +28,9 @@
 #include "memory/allocation.hpp"
 #include "oops/accessDecorators.hpp"
 #include "opto/loopnode.hpp"
+#include "opto/machnode.hpp"
 #include "opto/matcher.hpp"
 #include "opto/memnode.hpp"
-#include "opto/machnode.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 // This means the access is mismatched. This means the value of an access

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -942,3 +942,26 @@ void ZBarrierSetC2::eliminate_gc_barrier_data(Node* node) const {
     mem->set_barrier_data(ZBarrierElided);
   }
 }
+
+#ifndef PRODUCT
+void ZBarrierSetC2::dump_barrier_data(const MachNode* mach, outputStream* st) const {
+  if ((mach->barrier_data() & ZBarrierStrong) != 0) {
+    st->print("strong ");
+  }
+  if ((mach->barrier_data() & ZBarrierWeak) != 0) {
+    st->print("weak ");
+  }
+  if ((mach->barrier_data() & ZBarrierPhantom) != 0) {
+    st->print("phantom ");
+  }
+  if ((mach->barrier_data() & ZBarrierNoKeepalive) != 0) {
+    st->print("nokeepalive ");
+  }
+  if ((mach->barrier_data() & ZBarrierNative) != 0) {
+    st->print("native ");
+  }
+  if ((mach->barrier_data() & ZBarrierElided) != 0) {
+    st->print("elided ");
+  }
+}
+#endif // !PRODUCT

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
@@ -142,6 +142,10 @@ public:
   virtual void emit_stubs(CodeBuffer& cb) const;
   virtual void eliminate_gc_barrier(PhaseMacroExpand* macro, Node* node) const;
   virtual void eliminate_gc_barrier_data(Node* node) const;
+
+#ifndef PRODUCT
+  virtual void dump_barrier_data(const MachNode* mach, outputStream* st) const;
+#endif
 };
 
 #endif // SHARE_GC_Z_C2_ZBARRIERSETC2_HPP

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/shared/barrierSet.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "memory/universe.hpp"
 #include "oops/compressedOops.hpp"
@@ -534,6 +535,11 @@ void MachTypeNode::dump_spec(outputStream *st) const {
     _bottom_type->dump_on(st);
   } else {
     st->print(" NULL");
+  }
+  if (barrier_data() != 0) {
+    st->print(" barrier(");
+    BarrierSet::barrier_set()->barrier_set_c2()->dump_barrier_data(this, st);
+    st->print(")");
   }
 }
 #endif

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/barrierSet.hpp"
+#include "gc/shared/c2/barrierSetC2.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "memory/universe.hpp"
 #include "oops/compressedOops.hpp"

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -50,8 +50,8 @@ class Content {
 
 public class TestZGCBarrierElision {
 
-    static volatile Payload p = new Payload(new Content(5));
-    static volatile Content c1 = new Content(45);
+    static Payload p = new Payload(new Content(5));
+    static Content c1 = new Content(45);
 
     public static void main(String[] args) {
         TestFramework framework = new TestFramework();

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -39,9 +39,9 @@ import jdk.internal.misc.Unsafe;
 class Inner {}
 
 class Outer {
-    // This field is declared volatile to prevent C2 from optimizing memory
-    // accesses away.
-    volatile Inner inner;
+    // Declared volatile to prevent C2 from optimizing memory accesses away.
+    volatile Inner field1;
+    volatile Inner field2;
     public Outer() {}
 }
 
@@ -54,7 +54,8 @@ public class TestZGCBarrierElision {
 
     public static void main(String[] args) {
         TestFramework framework = new TestFramework();
-        Scenario zgc = new Scenario(0, "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED", "-XX:+UseZGC", "-XX:+UnlockExperimentalVMOptions", "-XX:CompileCommand=quiet",
+        Scenario zgc = new Scenario(0, "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                                    "-XX:+UseZGC", "-XX:+UnlockExperimentalVMOptions", "-XX:CompileCommand=quiet",
                                     "-XX:CompileCommand=blackhole,compiler.gcbarriers.TestZGCBarrierElision::blackhole");
         framework.addScenarios(zgc).start();
     }
@@ -68,8 +69,8 @@ public class TestZGCBarrierElision {
         // This blackhole is necessary to prevent C2 from optimizing away the entire body.
         blackhole(o1);
         // Two loads are required, the first one is directly optimized away.
-        blackhole(o1.inner);
-        blackhole(o1.inner);
+        blackhole(o1.field1);
+        blackhole(o1.field1);
     }
 
     @Test
@@ -78,39 +79,46 @@ public class TestZGCBarrierElision {
         Outer o1 = new Outer();
         // This blackhole is necessary to prevent C2 from optimizing away the entire body.
         blackhole(o1);
-        o1.inner = i;
+        o1.field1 = i;
     }
 
     @Test
     @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "strong", "1" }, phase = CompilePhase.FINAL_CODE)
     @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "elided", "1" }, phase = CompilePhase.FINAL_CODE)
     private static void testLoadThenLoad(Outer o, Inner i) {
-        blackhole(o.inner);
-        blackhole(o.inner);
+        blackhole(o.field1);
+        blackhole(o.field1);
     }
 
     @Test
     @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, "strong", "1" }, phase = CompilePhase.FINAL_CODE)
     @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, "elided", "1" }, phase = CompilePhase.FINAL_CODE)
     private static void testStoreThenStore(Outer o, Inner i) {
-        o.inner = i;
-        o.inner = i;
+        o.field1 = i;
+        o.field1 = i;
     }
 
     @Test
     @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, "strong", "1" }, phase = CompilePhase.FINAL_CODE)
     @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "elided", "1" },  phase = CompilePhase.FINAL_CODE)
     private static void testStoreThenLoad(Outer o, Inner i) {
-        o.inner = i;
-        blackhole(o.inner);
+        o.field1 = i;
+        blackhole(o.field1);
     }
 
     @Test
     @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, "strong", "1" }, phase = CompilePhase.FINAL_CODE)
     @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "strong", "1" },  phase = CompilePhase.FINAL_CODE)
     private static void testLoadThenStore(Outer o, Inner i) {
-        blackhole(o.inner);
-        o.inner = i;
+        blackhole(o.field1);
+        o.field1 = i;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "strong", "2" }, phase = CompilePhase.FINAL_CODE)
+    private static void testLoadThenLoadAnotherField(Outer o, Inner i) {
+        blackhole(o.field1);
+        blackhole(o.field2);
     }
 
     @Run(test = {"testAllocateThenLoad",
@@ -118,14 +126,16 @@ public class TestZGCBarrierElision {
                  "testLoadThenLoad",
                  "testStoreThenStore",
                  "testStoreThenLoad",
-                 "testLoadThenStore"})
-    private void runClassInstanceTests() {
+                 "testLoadThenStore",
+                 "testLoadThenLoadAnotherField"})
+    private void runBasicTests() {
         testAllocateThenLoad(outer, inner);
         testAllocateThenStore(outer, inner);
         testLoadThenLoad(outer, inner);
         testStoreThenStore(outer, inner);
         testStoreThenLoad(outer, inner);
         testLoadThenStore(outer, inner);
+        testLoadThenLoadAnotherField(outer, inner);
     }
 
     @Test
@@ -181,12 +191,22 @@ public class TestZGCBarrierElision {
         U.putReferenceVolatile(o, offset, o1);
     }
 
+    @Test
+    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "strong", "2" }, phase = CompilePhase.FINAL_CODE)
+    private static void testArrayLoadThenLoadAnotherElement(Outer[] o, Outer o1, Outer o2, Inner i) {
+        long offset = U.arrayBaseOffset(Outer[].class);
+        int scale = U.arrayIndexScale(Outer[].class);
+        blackhole(U.getReferenceVolatile(o, offset));
+        blackhole(U.getReferenceVolatile(o, offset + 10 * scale));
+    }
+
     @Run(test = {"testAllocateArrayThenStoreAtKnownIndex",
                  "testAllocateArrayThenStoreAtUnknownIndex",
                  "testArrayLoadThenLoad",
                  "testArrayStoreThenStore",
                  "testArrayStoreThenLoad",
-                 "testArrayLoadThenStore"})
+                 "testArrayLoadThenStore",
+                 "testArrayLoadThenLoadAnotherElement"})
     private void runArrayTests() {
         testAllocateArrayThenStoreAtKnownIndex(outer, inner);
         testAllocateArrayThenStoreAtUnknownIndex(outer, inner, 10);
@@ -194,5 +214,6 @@ public class TestZGCBarrierElision {
         testArrayStoreThenStore(outerArray, outer, outer, inner);
         testArrayStoreThenLoad(outerArray, outer, outer, inner);
         testArrayLoadThenStore(outerArray, outer, outer, inner);
+        testArrayLoadThenLoadAnotherElement(outerArray, outer, outer, inner);
     }
 }

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -304,7 +304,7 @@ public class TestZGCBarrierElision {
 
     @Test
     @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    // The atomic access barrier should be elided, but is not.
     private static void testStoreThenAtomic(Outer o, Inner i) {
         o.field1 = i;
         field1VarHandle.getAndSet​(o, i);
@@ -312,7 +312,7 @@ public class TestZGCBarrierElision {
 
     @Test
     @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    // The load barrier should be elided, but is not.
     private static void testAtomicThenLoad(Outer o, Inner i) throws Exception {
         field1VarHandle.getAndSet​(o, i);
         blackhole(o.field1);
@@ -320,15 +320,14 @@ public class TestZGCBarrierElision {
 
     @Test
     @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    // The store barrier should be elided, but is not.
     private static void testAtomicThenStore(Outer o, Inner i) {
         field1VarHandle.getAndSet​(o, i);
         o.field1 = i;
     }
 
     @Test
-    @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    // The second atomic access barrier should be elided, but is not.
     private static void testAtomicThenAtomic(Outer o, Inner i) {
         field1VarHandle.getAndSet​(o, i);
         field1VarHandle.getAndSet​(o, i);

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.gcbarriers;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.ir_framework.CompilePhase;
+
+/**
+ * @test
+ * @summary Test elision of dominating barriers in ZGC.
+ * @library /test/lib /
+ * @requires vm.gc.Z
+ * @run driver compiler.gcbarriers.TestZGCBarrierElision
+ */
+
+class Payload {
+    Content c;
+    public Payload(Content c) {
+        this.c = c;
+    }
+}
+
+class Content {
+    int id;
+    public Content(int id) {
+        this.id = id;
+    }
+}
+
+public class TestZGCBarrierElision {
+
+    Payload p = new Payload(new Content(5));
+    Content c1 = new Content(45);
+    Content c2 = new Content(15);
+
+    public static void main(String[] args) {
+        TestFramework framework = new TestFramework();
+        Scenario zgc = new Scenario(0, "-XX:+UseZGC", "-XX:+UnlockExperimentalVMOptions", "-XX:CompileCommand=quiet",
+                                       "-XX:CompileCommand=blackhole,compiler.gcbarriers.TestZGCBarrierElision::blackhole");
+        framework.addScenarios(zgc).start();
+    }
+
+    static void blackhole(Content t) {}
+
+    static void blackhole(Payload p) {}
+
+    @Test
+    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "strong", "1" },
+        phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "elided", "1" },
+        phase = CompilePhase.FINAL_CODE)
+    private static void testLoadFollowedByLoad(Payload p) {
+        Content t1 = p.c;
+        blackhole(t1);
+        Content t2 = p.c;
+        blackhole(t2);
+    }
+
+    @Test
+    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, "strong", "1" },
+        phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, "elided", "1" },
+        phase = CompilePhase.FINAL_CODE)
+    private static void testStoreFollowedByStore(Payload p, Content t1, Content t2) {
+        p.c = t1;
+        blackhole(p);
+        p.c = t2;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, "strong", "1" },
+        phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "elided", "1" },
+        phase = CompilePhase.FINAL_CODE)
+    private static void testStoreFollowedByLoad(Payload p, Content t1) {
+        p.c = t1;
+        blackhole(p);
+        Content t2 = p.c;
+        blackhole(t2);
+    }
+
+    @Test
+    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, "strong", "1" },
+        phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, "strong", "1" },
+        phase = CompilePhase.FINAL_CODE)
+    private static void testLoadFollowedByStore(Payload p, Content t1) {
+        Content t2 = p.c;
+        blackhole(t2);
+        p.c = t1;
+    }
+
+    @Run(test = {"testLoadFollowedByLoad",
+                 "testStoreFollowedByStore",
+                 "testStoreFollowedByLoad",
+                 "testLoadFollowedByStore"})
+    private void run() {
+        testLoadFollowedByLoad(p);
+        testStoreFollowedByStore(p, c1, c2);
+        testStoreFollowedByLoad(p, c1);
+        testLoadFollowedByStore(p, c1);
+    }
+}

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -26,7 +26,6 @@ package compiler.gcbarriers;
 import compiler.lib.ir_framework.*;
 import java.lang.invoke.VarHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodHandles.Lookup;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -35,7 +34,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *          volatile memory accesses and blackholes to prevent C2 from simply
  *          optimizing them away.
  * @library /test/lib /
- * @requires vm.gc.Z
+ * @requires vm.gc.Z & os.simpleArch == "x64"
  * @run driver compiler.gcbarriers.TestZGCBarrierElision
  */
 

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -84,7 +84,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateThenLoad() {
         Outer o1 = new Outer();
         blackhole(o1);
@@ -94,7 +94,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateThenStore(Inner i) {
         Outer o1 = new Outer();
         blackhole(o1);
@@ -102,46 +102,46 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testLoadThenLoad(Outer o) {
         blackhole(o.field1);
         blackhole(o.field1);
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testStoreThenStore(Outer o, Inner i) {
         o.field1 = i;
         o.field1 = i;
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, ELIDED, "1" },  phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, ELIDED, "1" },  phase = CompilePhase.FINAL_CODE)
     static void testStoreThenLoad(Outer o, Inner i) {
         o.field1 = i;
         blackhole(o.field1);
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, REMAINING, "1" },  phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, REMAINING, "1" },  phase = CompilePhase.FINAL_CODE)
     static void testLoadThenStore(Outer o, Inner i) {
         blackhole(o.field1);
         o.field1 = i;
     }
 
     @Test
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testLoadThenLoadAnotherField(Outer o) {
         blackhole(o.field1);
         blackhole(o.field2);
     }
 
     @Test
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testLoadThenLoadFromAnotherObject(Outer o1, Outer o2) {
         blackhole(o1.field1);
         blackhole(o2.field1);
@@ -167,7 +167,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateArrayThenStoreAtKnownIndex(Outer o) {
         Outer[] a = new Outer[42];
         blackhole(a);
@@ -175,7 +175,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateArrayThenStoreAtUnknownIndex(Outer o, int index) {
         Outer[] a = new Outer[42];
         blackhole(a);
@@ -183,39 +183,39 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayLoadThenLoad(Outer[] a) {
         blackhole(outerArrayVarHandle.getVolatile(a, 0));
         blackhole(outerArrayVarHandle.getVolatile(a, 0));
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayStoreThenStore(Outer[] a, Outer o) {
         outerArrayVarHandle.setVolatile(a, 0, o);
         outerArrayVarHandle.setVolatile(a, 0, o);
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayStoreThenLoad(Outer[] a, Outer o) {
         outerArrayVarHandle.setVolatile(a, 0, o);
         blackhole(outerArrayVarHandle.getVolatile(a, 0));
     }
 
     @Test
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayLoadThenStore(Outer[] a, Outer o) {
         blackhole(outerArrayVarHandle.getVolatile(a, 0));
         outerArrayVarHandle.setVolatile(a, 0, o);
     }
 
     @Test
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayLoadThenLoadAnotherElement(Outer[] a) {
         blackhole(outerArrayVarHandle.getVolatile(a, 0));
         blackhole(outerArrayVarHandle.getVolatile(a, 10));
@@ -239,8 +239,8 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testStoreThenConditionalStore(Outer o, Inner i, int value) {
         o.field1 = i;
         if (value % 2 == 0) {
@@ -249,7 +249,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testConditionalStoreThenStore(Outer o, Inner i, int value) {
         if (value % 2 == 0) {
             o.field1 = i;
@@ -258,8 +258,8 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testStoreThenStoreInLoop(Outer o, Inner i) {
         o.field1 = i;
         for (int j = 0; j < 100; j++) {
@@ -268,7 +268,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testStoreThenCallThenStore(Outer o, Inner i) {
         o.field1 = i;
         nonInlinedMethod();
@@ -287,7 +287,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAllocateThenAtomic(Inner i) {
         Outer o = new Outer();
         blackhole(o);
@@ -295,15 +295,15 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZLOADP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testLoadThenAtomic(Outer o, Inner i) {
         blackhole(o.field1);
         field1VarHandle.getAndSet​(o, i);
     }
 
     @Test
-    @IR(counts = { IRNode.ZSTOREP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     // The atomic access barrier should be elided, but is not.
     static void testStoreThenAtomic(Outer o, Inner i) {
         o.field1 = i;
@@ -311,7 +311,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     // The load barrier should be elided, but is not.
     static void testAtomicThenLoad(Outer o, Inner i) {
         field1VarHandle.getAndSet​(o, i);
@@ -319,7 +319,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     // The store barrier should be elided, but is not.
     static void testAtomicThenStore(Outer o, Inner i) {
         field1VarHandle.getAndSet​(o, i);
@@ -334,7 +334,7 @@ public class TestZGCBarrierElision {
     }
 
     @Test
-    @IR(counts = { IRNode.ZXCHGP_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenAtomicAnotherField(Outer o, Inner i) {
         field1VarHandle.getAndSet​(o, i);
         field2VarHandle.getAndSet​(o, i);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1355,6 +1355,12 @@ public class IRNode {
         machOnly(ZSTOREP_WITH_BARRIER_FLAG, regex);
     }
 
+    public static final String ZXCHGP_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "ZXCHGP_WITH_BARRIER_FLAG" + POSTFIX;
+    static {
+        String regex = START + "zXChgP" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
+        machOnly(ZXCHGP_WITH_BARRIER_FLAG, regex);
+    }
+
     /*
      * Utility methods to set up IR_NODE_MAPPINGS.
      */

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1341,6 +1341,17 @@ public class IRNode {
     public static final String XOR3_SVE = PREFIX + "XOR3_SVE" + POSTFIX;
     static {
         machOnlyNameRegex(XOR3_SVE, "veor3_sve");
+
+    public static final String ZLOADP_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "ZLOADP_WITH_BARRIER_FLAG" + POSTFIX;
+    static {
+        String regex = START + "zLoadP" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
+        machOnly(ZLOADP_WITH_BARRIER_FLAG, regex);
+    }
+
+    public static final String ZSTOREP_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "ZSTOREP_WITH_BARRIER_FLAG" + POSTFIX;
+    static {
+        String regex = START + "zStoreP" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
+        machOnly(ZSTOREP_WITH_BARRIER_FLAG, regex);
     }
 
     /*

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1341,6 +1341,7 @@ public class IRNode {
     public static final String XOR3_SVE = PREFIX + "XOR3_SVE" + POSTFIX;
     static {
         machOnlyNameRegex(XOR3_SVE, "veor3_sve");
+    }
 
     public static final String ZLOADP_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "ZLOADP_WITH_BARRIER_FLAG" + POSTFIX;
     static {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1343,22 +1343,22 @@ public class IRNode {
         machOnlyNameRegex(XOR3_SVE, "veor3_sve");
     }
 
-    public static final String ZLOADP_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "ZLOADP_WITH_BARRIER_FLAG" + POSTFIX;
+    public static final String Z_LOAD_P_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "Z_LOAD_P_WITH_BARRIER_FLAG" + POSTFIX;
     static {
-        String regex = START + "zLoadP" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
-        machOnly(ZLOADP_WITH_BARRIER_FLAG, regex);
+        String regex = START + "zLoadP\\S*" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
+        machOnly(Z_LOAD_P_WITH_BARRIER_FLAG, regex);
     }
 
-    public static final String ZSTOREP_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "ZSTOREP_WITH_BARRIER_FLAG" + POSTFIX;
+    public static final String Z_STORE_P_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "Z_STORE_P_WITH_BARRIER_FLAG" + POSTFIX;
     static {
-        String regex = START + "zStoreP" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
-        machOnly(ZSTOREP_WITH_BARRIER_FLAG, regex);
+        String regex = START + "zStoreP\\S*" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
+        machOnly(Z_STORE_P_WITH_BARRIER_FLAG, regex);
     }
 
-    public static final String ZXCHGP_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "ZXCHGP_WITH_BARRIER_FLAG" + POSTFIX;
+    public static final String Z_GET_AND_SET_P_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "Z_GET_AND_SET_P_WITH_BARRIER_FLAG" + POSTFIX;
     static {
-        String regex = START + "zXChgP" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
-        machOnly(ZXCHGP_WITH_BARRIER_FLAG, regex);
+        String regex = START + "(zXChgP)|(zGetAndSetP\\S*)" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
+        machOnly(Z_GET_AND_SET_P_WITH_BARRIER_FLAG, regex);
     }
 
     /*


### PR DESCRIPTION
This changeset adds test cases exercising C2's barrier elision on combinations of different

- pairs of dominating / dominated accesses (allocations, loads, stores, atomic operations),
- control structures (local, conditions, loops),
- object types (arrays, class instances), and
- levels of information available during C2's analysis (known vs. unknown array indices).

The changeset exposes node barrier data to the [IR test framework](https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/compiler/lib/ir_framework/README.md) by including it in the node's dump output. This extension is useful not just for testing but also for debugging purposes, for example when exploring C2's intermediate representation with IGV:

![igv](https://user-images.githubusercontent.com/8792647/216639224-aa288dd8-72cc-43a5-a445-a93d65004dac.png)

The following tests illustrate a missing optimization in C2's barrier elision (reported in [JDK-8301769](https://bugs.openjdk.org/browse/JDK-8301769)), where barriers that should be elided are not:

- `testStoreThenAtomic`
- `testAtomicThenLoad`
- `testAtomicThenStore`
- `testAtomicThenAtomic`

The changeset does not contain IR checks expecting elision in these cases, to reduce CI pipeline noise. The tests are restricted by now to x64, since volatile loads and stores in other platforms suffer from the same issue (see [JDK-8301769](https://bugs.openjdk.org/browse/JDK-8301769)).

**Testing:** tier1-7 (windows-x64, linux-x64, macosx-x64; release and debug mode)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301584](https://bugs.openjdk.org/browse/JDK-8301584): Generational ZGC: Add barrier elision tests


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [3a5ef481](https://git.openjdk.org/zgc/pull/12/files/3a5ef48136d90548f59ac7d33fa235e0777a0de2)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer) ⚠️ Review applies to [3a5ef481](https://git.openjdk.org/zgc/pull/12/files/3a5ef48136d90548f59ac7d33fa235e0777a0de2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/zgc pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/zgc pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/zgc/pull/12.diff">https://git.openjdk.org/zgc/pull/12.diff</a>

</details>
