### PR TITLE
8301769: Generational ZGC: Indirect access barriers are never elided

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -617,8 +617,8 @@ static const Node* get_base_and_offset(const MachNode* mach, intptr_t& offset) {
     // indirect memory operand (indicated by offset == 0). The ultimate base and
     // offset can be fetched directly from the inputs and Ideal type of 'base'.
     offset = base->bottom_type()->isa_oopptr()->offset();
-    // Even if 'base' is not an Ideal AddPNode anymore, the base address is
-    // still available at the same input slot in all MachNode implementations.
+    // Even if 'base' is not an Ideal AddP node anymore, Matcher::ReduceInst()
+    // guarantees that the base address is still available at the same slot.
     base = base->in(AddPNode::Base);
     assert(base != NULL, "");
   }

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -606,10 +606,24 @@ static bool is_concrete(intptr_t offset) {
 static const Node* get_base_and_offset(const MachNode* mach, intptr_t& offset) {
   const TypePtr* adr_type = NULL;
   offset = 0;
-  const Node* const base = mach->get_base_and_disp(offset, adr_type);
+  const Node* base = mach->get_base_and_disp(offset, adr_type);
 
-  if (base == NULL || base == NodeSentinel ||
-      is_undefined(offset) || (is_concrete(offset) && offset < 0)) {
+  if (base == NULL || base == NodeSentinel) {
+    return NULL;
+  }
+
+  if (offset == 0 && base->is_Mach() && base->as_Mach()->ideal_Opcode() == Op_AddP) {
+    // The memory address is computed by 'base' and fed to 'mach' via an
+    // indirect memory operand (indicated by offset == 0). The ultimate base and
+    // offset can be fetched directly from the inputs and Ideal type of 'base'.
+    offset = base->bottom_type()->isa_oopptr()->offset();
+    // Even if 'base' is not an Ideal AddPNode anymore, the base address is
+    // still available at the same input slot in all MachNode implementations.
+    base = base->in(AddPNode::Base);
+    assert(base != NULL, "");
+  }
+
+  if (is_undefined(offset) || (is_concrete(offset) && offset < 0)) {
     return NULL;
   }
 

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -353,22 +353,22 @@ public class TestZGCBarrierElision {
     static void testAllocateArrayThenAtomicAtUnknownIndex(Outer o, int index) {
         Outer[] a = new Outer[42];
         blackhole(a);
-        outerArrayVarHandle.getAndSet(a, index + 1, o);
+        outerArrayVarHandle.getAndSet(a, index, o);
     }
 
     @Test
     @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
     @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayAtomicThenAtomic(Outer[] a, Outer o) {
-        blackhole(outerArrayVarHandle.getAndSet(a, 0, o));
-        blackhole(outerArrayVarHandle.getAndSet(a, 0, o));
+        outerArrayVarHandle.getAndSet(a, 0, o);
+        outerArrayVarHandle.getAndSet(a, 0, o);
     }
 
     @Test
     @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
     static void testArrayAtomicThenAtomicAtUnknownIndices(Outer[] a, Outer o, int index1, int index2) {
-        blackhole(outerArrayVarHandle.getAndSet(a, index1, o));
-        blackhole(outerArrayVarHandle.getAndSet(a, index2, o));
+        outerArrayVarHandle.getAndSet(a, index1, o);
+        outerArrayVarHandle.getAndSet(a, index2, o);
     }
 
     @Run(test = {"testAllocateThenAtomic",

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -303,7 +303,7 @@ public class TestZGCBarrierElision {
 
     @Test
     @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    // The atomic access barrier should be elided, but is not.
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testStoreThenAtomic(Outer o, Inner i) {
         o.field1 = i;
         field1VarHandle.getAndSet​(o, i);
@@ -311,7 +311,7 @@ public class TestZGCBarrierElision {
 
     @Test
     @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    // The load barrier should be elided, but is not.
+    @IR(counts = { IRNode.Z_LOAD_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenLoad(Outer o, Inner i) {
         field1VarHandle.getAndSet​(o, i);
         blackhole(o.field1);
@@ -319,14 +319,15 @@ public class TestZGCBarrierElision {
 
     @Test
     @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
-    // The store barrier should be elided, but is not.
+    @IR(counts = { IRNode.Z_STORE_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenStore(Outer o, Inner i) {
         field1VarHandle.getAndSet​(o, i);
         o.field1 = i;
     }
 
     @Test
-    // The second atomic access barrier should be elided, but is not.
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
     static void testAtomicThenAtomic(Outer o, Inner i) {
         field1VarHandle.getAndSet​(o, i);
         field1VarHandle.getAndSet​(o, i);

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *          volatile memory accesses and blackholes to prevent C2 from simply
  *          optimizing them away.
  * @library /test/lib /
- * @requires vm.gc.Z & os.simpleArch == "x64"
+ * @requires vm.gc.Z & (vm.simpleArch == "x64" | vm.simpleArch == "aarch64")
  * @run driver compiler.gcbarriers.TestZGCBarrierElision
  */
 

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -340,21 +340,59 @@ public class TestZGCBarrierElision {
         field2VarHandle.getAndSet​(o, i);
     }
 
+    @Test
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    static void testAllocateArrayThenAtomicAtKnownIndex(Outer o) {
+        Outer[] a = new Outer[42];
+        blackhole(a);
+        outerArrayVarHandle.getAndSet(a, 2, o);
+    }
+
+    @Test
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    static void testAllocateArrayThenAtomicAtUnknownIndex(Outer o, int index) {
+        Outer[] a = new Outer[42];
+        blackhole(a);
+        outerArrayVarHandle.getAndSet(a, index + 1, o);
+    }
+
+    @Test
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "1" }, phase = CompilePhase.FINAL_CODE)
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, ELIDED, "1" }, phase = CompilePhase.FINAL_CODE)
+    static void testArrayAtomicThenAtomic(Outer[] a, Outer o) {
+        blackhole(outerArrayVarHandle.getAndSet(a, 0, o));
+        blackhole(outerArrayVarHandle.getAndSet(a, 0, o));
+    }
+
+    @Test
+    @IR(counts = { IRNode.Z_GET_AND_SET_P_WITH_BARRIER_FLAG, REMAINING, "2" }, phase = CompilePhase.FINAL_CODE)
+    static void testArrayAtomicThenAtomicAtUnknownIndices(Outer[] a, Outer o, int index1, int index2) {
+        blackhole(outerArrayVarHandle.getAndSet(a, index1, o));
+        blackhole(outerArrayVarHandle.getAndSet(a, index2, o));
+    }
+
     @Run(test = {"testAllocateThenAtomic",
                  "testLoadThenAtomic",
                  "testStoreThenAtomic",
                  "testAtomicThenLoad",
                  "testAtomicThenStore",
                  "testAtomicThenAtomic",
-                 "testAtomicThenAtomicAnotherField"})
+                 "testAtomicThenAtomicAnotherField",
+                 "testAllocateArrayThenAtomicAtKnownIndex",
+                 "testAllocateArrayThenAtomicAtUnknownIndex",
+                 "testArrayAtomicThenAtomic",
+                 "testArrayAtomicThenAtomicAtUnknownIndices"})
     void runAtomicOperationTests() {
-            testAllocateThenAtomic(inner);
-            testLoadThenAtomic(outer, inner);
-            testStoreThenAtomic(outer, inner);
-            testAtomicThenLoad(outer, inner);
-            testAtomicThenStore(outer, inner);
-            testAtomicThenAtomic(outer, inner);
-            testAtomicThenAtomicAnotherField(outer, inner);
+        testAllocateThenAtomic(inner);
+        testLoadThenAtomic(outer, inner);
+        testStoreThenAtomic(outer, inner);
+        testAtomicThenLoad(outer, inner);
+        testAtomicThenStore(outer, inner);
+        testAtomicThenAtomic(outer, inner);
+        testAtomicThenAtomicAnotherField(outer, inner);
+        testAllocateArrayThenAtomicAtKnownIndex(outer);
+        testAllocateArrayThenAtomicAtUnknownIndex(outer, 10);
+        testArrayAtomicThenAtomic(outerArray, outer);
+        testArrayAtomicThenAtomicAtUnknownIndices(outerArray, outer, 10, 20);
     }
-
 }


### PR DESCRIPTION
This changeset extends barrier elision analysis to handle atomic (x64, riscv, aarch64) and volatile (aarch64) memory access instructions. Offset-based addressing modes are unavailable or disabled for these instructions, which defeats the regular [address component analysis](https://github.com/openjdk/zgc/blob/c16d33431f13e927f40b1fde99c5877f5a5eca6e/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp#L606-L617) (finding the base and offset of an address) that is central to barrier elision analysis. The changeset extends the address component analysis with special handling to detect and extract the component information from the inputs and Ideal type of the address computation node. The proposed extension relies on the fact that AddP-matched Mach nodes contain the base address in the same input slot, as [guaranteed by Matcher::ReduceInst()](https://github.com/openjdk/zgc/blob/c16d33431f13e927f40b1fde99c5877f5a5eca6e/src/hotspot/share/opto/matcher.cpp#L1838-L1841).

The changeset also adds additional test cases that exercise analysis of atomic accesses on arrays, with the goal of testing more complex address computations, and enables the tests in aarch64. @TheRealMDoerr, @RealFYang: please let me know if you want to try out the tests on the other ZGC-supporting architectures and enable them as part of this changeset or handle that later.

**Testing:** tier1-7 (x64 and aaarch64; linux, windows, and macosx; release and debug mode)

#### Alternative solutions

Three alternative solutions were explored and discarded in favor of this one:

- Re-enable addressing modes for x64 atomics by duplicating the ADL instruction rules (see [prototype](https://github.com/openjdk/zgc/compare/zgc_generational...robcasloz:zgc:JDK-8301769-duplicate-adl-rules)). This enables the regular address component analysis for x64 but does not improve the situation for the other architectures. Furthermore, it makes the ZGC-specific ADL code less maintainable.

- Re-enable addressing modes for x64 atomics by introducing an ADL construct (e.g. an "operand effect") to enforce that a certain operand is always assigned a distinct register from the other operands. This has the same effect as the above alternative without affecting the readability of the ZGC-specific ADL code, but it still does not solve the issue for the other architectures.

- Extend the address component analysis with special handling as in this changeset, but performing a local analysis of the input address computation node (see [prototype](https://github.com/openjdk/zgc/compare/zgc_generational...robcasloz:zgc:JDK-8301769-mach-analysis)). This has a similar effect as this changeset for x64 but is less effective for other architectures with simpler addressing modes such as aarch64, where address computations are sometimes performed in multiple steps.

An open question is whether the local scope of the regular address component analysis affects the effectiveness of barrier elision for regular (non-atomic, non-volatile) memory accesses in architectures with more limited addressing modes than x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301769](https://bugs.openjdk.org/browse/JDK-8301769): Generational ZGC: Indirect access barriers are never elided


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/zgc pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/zgc pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/zgc/pull/13.diff">https://git.openjdk.org/zgc/pull/13.diff</a>

</details>
