### PR TITLE
Remove bad metadata bits cleanup on aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -673,9 +673,9 @@ void ZBarrierSetAssembler::copy_load_at(MacroAssembler* masm,
   }
 }
 
-static void remove_metadata_bits(MacroAssembler* masm,
-                                 Register ref,
-                                 Register tmp) {
+static void color_source(MacroAssembler* masm,
+                         Register ref,
+                         Register tmp) {
   // Set store-good color, replacing whatever color was there before
   __ ldr(tmp, Address(rthread, ZThreadLocalData::store_good_mask_offset()));
   __ bfi(ref, tmp, 0, 16);
@@ -725,10 +725,10 @@ void ZBarrierSetAssembler::copy_store_at(MacroAssembler* masm,
   }
 
   if (bytes == 8) {
-    remove_metadata_bits(masm, src1, tmp1);
+    color_source(masm, src1, tmp1);
   } else if (bytes == 16) {
-    remove_metadata_bits(masm, src1, tmp1);
-    remove_metadata_bits(masm, src2, tmp1);
+    color_source(masm, src1, tmp1);
+    color_source(masm, src2, tmp1);
   } else {
     ShouldNotReachHere();
   }

--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -555,6 +555,10 @@ static void copy_store_barrier(MacroAssembler* masm,
   }
 
   __ bind(done);
+
+  if (new_ref == noreg) {
+    __ str(pre_ref, src);
+  }
 }
 
 static void color_and_store_source(MacroAssembler* masm,

--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -784,8 +784,12 @@ void ZBarrierSetAssembler::copy_store_at(MacroAssembler* masm,
   dst = adjust.address();
 
   if (is_dest_uninitialized) {
-    copy_store_barrier_done(masm, src1, Address(dst.base(), dst.offset() + 0), tmp1, tmp2);
-    copy_store_barrier_done(masm, src2, Address(dst.base(), dst.offset() + 16), tmp1, tmp2);
+    if (bytes == 32) {
+      copy_store_barrier_done(masm, src1, Address(dst.base(), dst.offset() + 0), tmp1, tmp2);
+      copy_store_barrier_done(masm, src2, Address(dst.base(), dst.offset() + 16), tmp1, tmp2);
+    } else {
+      ShouldNotReachHere();
+    }
   } else {
     // Load pre values
     BarrierSetAssembler::copy_load_at(masm, decorators, type, bytes, vec_tmp1, vec_tmp2, dst, noreg, noreg, fnoreg);


### PR DESCRIPTION
Hi @fisk 

I cleanup the code about remove bad metadata bits for aarch64.

I debug the code on aarch64 machine which support `BIC` as equivalent to x86_64 `VPANDN` Logical AND NOT instruction:

```
(gdb) x/22i $pc-44
   0xffffe01e8748:      sub     x1, x1, #0x20
   0xffffe01e874c:      cmp     x15, #0x8
   0xffffe01e8750:      b.ge    0xffffe01e8760  // b.tcont
   0xffffe01e8754:      dcps1   #0xdeae
   0xffffe01e8758:      .inst   0xf7848dc0 ; undefined
   0xffffe01e875c:      .inst   0x0000ffff ; undefined
   0xffffe01e8760:      ldp     q0, q1, [x0, #32]
   0xffffe01e8764:      and     v6.16b, v0.16b, v11.16b
   0xffffe01e8768:      umaxv   b6, v6.16b
   0xffffe01e876c:      fcmp    d6, #0.0
   0xffffe01e8770:      b.ne    0xffffe01e8780  // b.any
=> 0xffffe01e8774:      brk     #0x0
   0xffffe01e8778:      bic     v0.16b, v0.16b, v9.16b
   0xffffe01e877c:      b       0xffffe01e8908
   0xffffe01e8780:      mov     x9, v0.d[0]
   0xffffe01e8784:      ldr     x8, [x28, #48]
   0xffffe01e8788:      tst     x9, x8
   0xffffe01e878c:      b.eq    0xffffe01e8840  // b.none
   0xffffe01e8790:      stp     x29, x30, [sp, #-16]!
   0xffffe01e8794:      mov     x29, sp
   0xffffe01e8798:      stp     x0, x1, [sp, #-144]!
   0xffffe01e879c:      stp     x2, x3, [sp, #16]
(gdb) i r v0 v9
v0             {d = {f = {0x0, 0x0}, u = {0x80000825bd0e510, 0x80000825d08e510}, s = {0x80000825bd0e510, 0x80000825d08e510}}, s = {f = {0x0, 0x0, 0x0, 0x0}, u = {0x5bd0e510, 0x8000082, 0x5d08e510, 0x8000082}, s = {0x5bd0e510, 0x8000082, 0x5d08e510, 0x8000082}}, h = {u = {0xe510, 0x5bd0, 0x82, 0x800, 0xe510, 0x5d08, 0x82, 0x800}, s = {0xe510, 0x5bd0, 0x82, 0x800, 0xe510, 0x5d08, 0x82, 0x800}}, b = {u = {0x10, 0xe5, 0xd0, 0x5b, 0x82, 0x0, 0x0, 0x8, 0x10, 0xe5, 0x8, 0x5d, 0x82, 0x0, 0x0, 0x8}, s = {0x10, 0xe5, 0xd0, 0x5b, 0x82, 0x0, 0x0, 0x8, 0x10, 0xe5, 0x8, 0x5d, 0x82, 0x0, 0x0, 0x8}}, q = {u = {0x80000825d08e510080000825bd0e510}, s = {0x80000825d08e510080000825bd0e510}}}
v9             {d = {f = {0x0, 0x0}, u = {0x1ae0, 0x1ae0}, s = {0x1ae0, 0x1ae0}}, s = {f = {0x0, 0x0, 0x0, 0x0}, u = {0x1ae0, 0x0, 0x1ae0, 0x0}, s = {0x1ae0, 0x0, 0x1ae0, 0x0}}, h = {u = {0x1ae0, 0x0, 0x0, 0x0, 0x1ae0, 0x0, 0x0, 0x0}, s = {0x1ae0, 0x0, 0x0, 0x0, 0x1ae0, 0x0, 0x0, 0x0}}, b = {u = {0xe0, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, s = {0xe0, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}}, q = {u = {0x1ae00000000000001ae0}, s = {0x1ae00000000000001ae0}}}
(gdb) set $pc+=4
(gdb) si
0x0000ffffe01e877c in ?? ()
(gdb) i r v0 v9
v0             {d = {f = {0x0, 0x0}, u = {0x80000825bd0e510, 0x80000825d08e510}, s = {0x80000825bd0e510, 0x80000825d08e510}}, s = {f = {0x0, 0x0, 0x0, 0x0}, u = {0x5bd0e510, 0x8000082, 0x5d08e510, 0x8000082}, s = {0x5bd0e510, 0x8000082, 0x5d08e510, 0x8000082}}, h = {u = {0xe510, 0x5bd0, 0x82, 0x800, 0xe510, 0x5d08, 0x82, 0x800}, s = {0xe510, 0x5bd0, 0x82, 0x800, 0xe510, 0x5d08, 0x82, 0x800}}, b = {u = {0x10, 0xe5, 0xd0, 0x5b, 0x82, 0x0, 0x0, 0x8, 0x10, 0xe5, 0x8, 0x5d, 0x82, 0x0, 0x0, 0x8}, s = {0x10, 0xe5, 0xd0, 0x5b, 0x82, 0x0, 0x0, 0x8, 0x10, 0xe5, 0x8, 0x5d, 0x82, 0x0, 0x0, 0x8}}, q = {u = {0x80000825d08e510080000825bd0e510}, s = {0x80000825d08e510080000825bd0e510}}}
v9             {d = {f = {0x0, 0x0}, u = {0x1ae0, 0x1ae0}, s = {0x1ae0, 0x1ae0}}, s = {f = {0x0, 0x0, 0x0, 0x0}, u = {0x1ae0, 0x0, 0x1ae0, 0x0}, s = {0x1ae0, 0x0, 0x1ae0, 0x0}}, h = {u = {0x1ae0, 0x0, 0x0, 0x0, 0x1ae0, 0x0, 0x0, 0x0}, s = {0x1ae0, 0x0, 0x0, 0x0, 0x1ae0, 0x0, 0x0, 0x0}}, b = {u = {0xe0, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, s = {0xe0, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}}, q = {u = {0x1ae00000000000001ae0}, s = {0x1ae00000000000001ae0}}}
```

aarch64 fastdebug hotspot:tier1:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
>> jtreg:test/hotspot/jtreg:tier1                     1688  1651    32     5 <<
==============================
```

Please review my patch!

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/zgc pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/zgc pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/zgc/pull/15.diff">https://git.openjdk.org/zgc/pull/15.diff</a>

</details>
