### PR TITLE
copy_load_barrier slow path color cleanup

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -484,11 +484,8 @@ static void copy_load_barrier(MacroAssembler* masm,
       __ mov(c_rarg0, ref);
     }
 
-    __ call_VM_leaf(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_addr(IN_HEAP | ON_STRONG_OOP_REF), 2);
+    __ call_VM_leaf(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_store_good_addr(), 2);
   }
-
-  // Slow-path has uncolored; revert
-  __ lsl(ref, ref, ZPointerLoadShift);
 
   __ bind(done);
 }

--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -463,9 +463,8 @@ void ZBarrierSetAssembler::copy_load_at_slow(MacroAssembler* masm,
     ZRuntimeCallSpill rcs(masm, R0, MacroAssembler::PRESERVATION_FRAME_LR_GP_REGS);
     assert(zpointer != R4_ARG2, "or change argument setup");
     __ mr_if_needed(R4_ARG2, addr);
-    __ call_VM_leaf(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_addr(), zpointer, R4_ARG2);
+    __ call_VM_leaf(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_store_good_addr(), zpointer, R4_ARG2);
   }
-  __ sldi(zpointer, R0, ZPointerLoadShift); // Slow-path has uncolored; revert
   __ mtctr(tmp); // restore loop counter
   __ b(continuation);
 }

--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
@@ -449,11 +449,8 @@ static void copy_load_barrier(MacroAssembler* masm,
       __ mv(c_rarg0, ref);
     }
 
-    __ call_VM_leaf(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_addr(IN_HEAP | ON_STRONG_OOP_REF), 2);
+    __ call_VM_leaf(ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_store_good_addr(), 2);
   }
-
-  // Slow-path has uncolored; revert
-  __ slli(ref, ref, ZPointerLoadShift);
 
   __ bind(done);
 }


### PR DESCRIPTION
Hi,

It is just able to save one Logical Shift Left instruction, for example:

```
void copy_load_barrier(...)  {
if test ZPointerLoadBadMask NE goto slow_path
slow_path:
call ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_store_good_addr instead
=> __ lsl(ref, ref, ZPointerLoadShift); // just save one instruction
...
}
```

Please review my path.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/zgc pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/zgc pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/zgc/pull/17.diff">https://git.openjdk.org/zgc/pull/17.diff</a>

</details>
